### PR TITLE
Add column ranges

### DIFF
--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -9,6 +9,7 @@ module XReferee.SearchResult (
   Anchor (..),
   Reference (..),
   Label (..),
+  ColumnRange (..),
   LabelLoc (..),
   findRefsFromGit,
 ) where
@@ -77,11 +78,21 @@ instance Label Reference where
 data LabelLoc = LabelLoc
   { filepath :: FilePath
   , lineNum :: Int
+  , columnRange :: ColumnRange
   }
   deriving (Show, Eq, Ord)
 
+data ColumnRange = ColumnRange
+  { start :: Int
+  , end :: Int
+  }
+  deriving (Show, Eq, Ord)
+
+instance NFData ColumnRange where
+  rnf (ColumnRange start end) = rnf start `seq` rnf end
+
 instance NFData LabelLoc where
-  rnf loc = rnf loc.filepath `seq` rnf loc.lineNum
+  rnf loc = rnf loc.filepath `seq` rnf loc.lineNum `seq` rnf loc.columnRange
 
 findRefsFromGit :: SearchOpts -> IO SearchResult
 findRefsFromGit opts = do
@@ -115,33 +126,55 @@ findRefsFromGit opts = do
       [filepath, lineNumStr, colNumStr, rest] <- pure $ TextL.splitOn "\0" line
       lineNum <- readMaybe $ TextL.unpack lineNumStr
       colNum <- readMaybe $ TextL.unpack colNumStr
-      let (anchors, references) = parseLabels $ TextL.drop (colNum - 1) rest
-          loc =
+      let (anchors, references) = parseLabels (TextL.drop (fromIntegral colNum - 1) rest) colNum
+          mkLoc columnRange =
             LabelLoc
               { filepath = TextL.unpack filepath
               , lineNum
+              , columnRange
               }
       pure
         SearchResult
-          { anchors = Map.fromListWith (<>) [(anchor, [loc]) | anchor <- anchors]
-          , references = Map.fromListWith (<>) [(ref, [loc]) | ref <- references]
+          { anchors = Map.fromListWith (<>) [(anchor, [mkLoc range]) | (anchor, range) <- anchors]
+          , references = Map.fromListWith (<>) [(ref, [mkLoc range]) | (ref, range) <- references]
           }
 
-parseLabels :: TextL.Text -> ([Anchor], [Reference])
+-- | Parse all labels from the given text.
+parseLabels ::
+  -- | The text to parse for labels.
+  TextL.Text ->
+  -- | The column number for the first character in the input text. Used to calculate the column numbers for the labels.
+  Int ->
+  ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
 parseLabels = parseSomeMarker [] []
   where
     markerStarts = map Text.head [anchorStart, refStart]
 
-    parseSomeMarker anchors refs s0 =
-      let s1 = dropNonMarker s0
+    parseSomeMarker ::
+      [(Anchor, ColumnRange)] ->
+      [(Reference, ColumnRange)] ->
+      TextL.Text ->
+      Int ->
+      ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
+    parseSomeMarker anchors refs s0 col0 =
+      -- Remove the prefix before the next marker, and update the column number accordingly.
+      let (prefix, s1) = TextL.break (`elem` markerStarts) s0
+          col1 = col0 + fromIntegral (TextL.length prefix)
        in case (Left <$> parseAnchor s1) <|> (Right <$> parseRef s1) of
-            Just (Left (name, s2)) -> parseSomeMarker (Anchor (TextL.toStrict name) : anchors) refs s2
-            Just (Right (name, s2)) -> parseSomeMarker anchors (Reference (TextL.toStrict name) : refs) s2
+            Just (Left (name, s2)) ->
+              let markerLen = Text.length anchorStart + fromIntegral (TextL.length name) + Text.length anchorEnd
+                  columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
+                  -- Advance the column number to match the remaining string `s2`
+                  col2 = col1 + markerLen
+               in parseSomeMarker ((Anchor (TextL.toStrict name), columnRange) : anchors) refs s2 col2
+            Just (Right (name, s2)) ->
+              let markerLen = Text.length refStart + fromIntegral (TextL.length name) + Text.length refEnd
+                  columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
+                  col2 = col1 + markerLen
+               in parseSomeMarker anchors ((Reference (TextL.toStrict name), columnRange) : refs) s2 col2
             Nothing
               | TextL.null s1 -> (anchors, refs)
-              | otherwise -> parseSomeMarker anchors refs (TextL.drop 1 s1)
-
-    dropNonMarker = snd . TextL.break (`elem` markerStarts)
+              | otherwise -> parseSomeMarker anchors refs (TextL.drop 1 s1) (col1 + 1)
 
     parseAnchor = parseMarker anchorStart anchorEnd
     parseRef = parseMarker refStart refEnd

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -127,7 +127,7 @@ findRefsFromGit opts = do
       [filepath, lineNumStr, colNumStr, rest] <- pure $ TextL.splitOn "\0" line
       lineNum <- readMaybe $ TextL.unpack lineNumStr
       colNum <- readMaybe $ TextL.unpack colNumStr
-      let (anchors, references) = parseLabels (TextL.drop (fromIntegral colNum - 1) rest) colNum
+      let (anchors, references) = parseLabels rest colNum
           mkLoc columnRange =
             LabelLoc
               { filepath = TextL.unpack filepath
@@ -144,10 +144,15 @@ findRefsFromGit opts = do
 parseLabels ::
   -- | The text to parse for labels.
   TextL.Text ->
-  -- | The column number for the first character in the input text. Used to calculate the column numbers for the labels.
+  -- | The column number of the first label in the input text. Used to calculate the column numbers for the labels.
   Int ->
   ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
-parseLabels = parseSomeMarker [] []
+parseLabels text col =
+  parseSomeMarker
+    []
+    []
+    (TextL.drop (fromIntegral col - 1) text)
+    col
   where
     markerStarts = map Text.head [anchorStart, refStart]
 

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -12,6 +12,7 @@ module XReferee.SearchResult (
   ColumnRange (..),
   LabelLoc (..),
   findRefsFromGit,
+  parseLabels,
 ) where
 
 import Control.Applicative ((<|>))

--- a/test/XReferee/IntegrationSpec.hs
+++ b/test/XReferee/IntegrationSpec.hs
@@ -10,14 +10,13 @@ import Skeletest
 import XReferee.Report (makeReport, renderReport, reportFailure)
 import XReferee.SearchResult (
   Anchor (..),
-  ColumnRange (..),
   LabelLoc (..),
   Reference (..),
   SearchResult (..),
   findRefsFromGit,
  )
 import XReferee.TestUtils.API (defaultOpts)
-import XReferee.TestUtils.Fixtures (getGitFixtures)
+import XReferee.TestUtils.Fixtures (Loc (..), getGitFixtures)
 import XReferee.TestUtils.Fixtures qualified as Fixture
 import XReferee.TestUtils.Git (withGitRepo)
 
@@ -28,39 +27,26 @@ spec = do
       fixtures <- getGitFixtures
       forM_ fixtures $ \(fixturePath, loadFixture) -> do
         fixture <- loadFixture
-        let expectedAnchors =
-              Map.mapKeys Anchor
-                . Map.map ((: []) . fromFixtureLoc)
-                $ fixture.anchors
-            expectedRefs =
-              Map.mapKeys Reference
-                . Map.map (map fromFixtureLoc)
-                $ fixture.refs
+        let expectedAnchors = Map.mapKeys Anchor fixture.anchors
+            expectedRefs = Map.mapKeys Reference fixture.refs
 
         withGitRepo fixture.files $ do
           result <- findRefsFromGit defaultOpts
           context fixturePath $ do
             -- Manually iterate to show smaller errors
-            forM_ (Map.toList expectedAnchors) $ \(anchor, locs) ->
+            forM_ (Map.toList expectedAnchors) $ \(anchor, loc) ->
               context (show anchor) $
-                Set.fromList (toFileAndLine <$> Map.findWithDefault [] anchor result.anchors)
-                  `shouldBe` Set.fromList (toFileAndLine <$> locs)
+                Map.findWithDefault [] anchor result.anchors `shouldMatchLocs` [loc]
             forM_ (Map.toList expectedRefs) $ \(ref, locs) ->
               context (show ref) $
-                Set.fromList (toFileAndLine <$> Map.findWithDefault [] ref result.references)
-                  `shouldBe` Set.fromList (toFileAndLine <$> locs)
+                Map.findWithDefault [] ref result.references `shouldMatchLocs` locs
           let report = makeReport result
           context fixturePath . context (Text.unpack $ renderReport report) $
             reportFailure report `shouldBe` False
   where
-    fromFixtureLoc loc =
-      LabelLoc
-        { filepath = loc.file
-        , lineNum = loc.lineNum
-        , columnRange = ColumnRange 0 0
-        }
-
-    -- Ignore `LabelLoc.columnRange` for the purpose of integration tests,
-    -- since column ranges are not part of the report.
-    toFileAndLine :: LabelLoc -> (FilePath, Int)
-    toFileAndLine loc = (loc.filepath, loc.lineNum)
+    shouldMatchLocs :: [LabelLoc] -> [Loc] -> IO ()
+    labelLocs `shouldMatchLocs` locs = Set.fromList (toLoc <$> labelLocs) `shouldBe` Set.fromList locs
+      where
+        -- Ignore `LabelLoc.columnRange` for the purpose of integration tests,
+        -- since column ranges are not part of the report.
+        toLoc (LabelLoc file lineNum _columnRange) = Loc{file, Fixture.lineNum}

--- a/test/XReferee/IntegrationSpec.hs
+++ b/test/XReferee/IntegrationSpec.hs
@@ -10,6 +10,7 @@ import Skeletest
 import XReferee.Report (makeReport, renderReport, reportFailure)
 import XReferee.SearchResult (
   Anchor (..),
+  ColumnRange (..),
   LabelLoc (..),
   Reference (..),
   SearchResult (..),
@@ -42,10 +43,12 @@ spec = do
             -- Manually iterate to show smaller errors
             forM_ (Map.toList expectedAnchors) $ \(anchor, locs) ->
               context (show anchor) $
-                Set.fromList (Map.findWithDefault [] anchor result.anchors) `shouldBe` Set.fromList locs
+                Set.fromList (toFileAndLine <$> Map.findWithDefault [] anchor result.anchors)
+                  `shouldBe` Set.fromList (toFileAndLine <$> locs)
             forM_ (Map.toList expectedRefs) $ \(ref, locs) ->
               context (show ref) $
-                Set.fromList (Map.findWithDefault [] ref result.references) `shouldBe` Set.fromList locs
+                Set.fromList (toFileAndLine <$> Map.findWithDefault [] ref result.references)
+                  `shouldBe` Set.fromList (toFileAndLine <$> locs)
           let report = makeReport result
           context fixturePath . context (Text.unpack $ renderReport report) $
             reportFailure report `shouldBe` False
@@ -54,4 +57,10 @@ spec = do
       LabelLoc
         { filepath = loc.file
         , lineNum = loc.lineNum
+        , columnRange = ColumnRange 0 0
         }
+
+    -- Ignore `LabelLoc.columnRange` for the purpose of integration tests,
+    -- since column ranges are not part of the report.
+    toFileAndLine :: LabelLoc -> (FilePath, Int)
+    toFileAndLine loc = (loc.filepath, loc.lineNum)

--- a/test/XReferee/ReportSpec.hs
+++ b/test/XReferee/ReportSpec.hs
@@ -12,10 +12,14 @@ import XReferee.Report (
  )
 import XReferee.SearchResult (
   Anchor (..),
+  ColumnRange (..),
   LabelLoc (..),
   Reference (..),
   SearchResult (..),
  )
+
+dummyColumnRange :: ColumnRange
+dummyColumnRange = ColumnRange 0 0
 
 spec :: Spec
 spec = do
@@ -25,15 +29,15 @@ spec = do
             SearchResult
               { anchors =
                   Map.fromList
-                    [ (Anchor "foo", [LabelLoc "foo_anchor.py" 1])
-                    , (Anchor "unused", [LabelLoc "unused.py" 2])
-                    , (Anchor "dup", [LabelLoc "dup1.py" 3, LabelLoc "dup2.py" 4])
+                    [ (Anchor "foo", [LabelLoc "foo_anchor.py" 1 dummyColumnRange])
+                    , (Anchor "unused", [LabelLoc "unused.py" 2 dummyColumnRange])
+                    , (Anchor "dup", [LabelLoc "dup1.py" 3 dummyColumnRange, LabelLoc "dup2.py" 4 dummyColumnRange])
                     ]
               , references =
                   Map.fromList
-                    [ (Reference "foo", [LabelLoc "foo_ref.py" 1])
-                    , (Reference "broken", [LabelLoc "broken.py" 2])
-                    , (Reference "dup", [LabelLoc "dup1.py" 3, LabelLoc "dup2.py" 4])
+                    [ (Reference "foo", [LabelLoc "foo_ref.py" 1 dummyColumnRange])
+                    , (Reference "broken", [LabelLoc "broken.py" 2 dummyColumnRange])
+                    , (Reference "dup", [LabelLoc "dup1.py" 3 dummyColumnRange, LabelLoc "dup2.py" 4 dummyColumnRange])
                     ]
               }
       (renderReport . makeReport) result `shouldSatisfy` P.matchesSnapshot
@@ -45,7 +49,7 @@ spec = do
               { anchors = Map.fromList []
               , references =
                   Map.fromList
-                    [ (Reference "broken", [LabelLoc "broken.py" 2])
+                    [ (Reference "broken", [LabelLoc "broken.py" 2 dummyColumnRange])
                     ]
               }
       (reportFailure . makeReport) result `shouldBe` True
@@ -55,7 +59,7 @@ spec = do
             SearchResult
               { anchors =
                   Map.fromList
-                    [ (Anchor "unused", [LabelLoc "unused.py" 1])
+                    [ (Anchor "unused", [LabelLoc "unused.py" 1 dummyColumnRange])
                     ]
               , references = Map.fromList []
               }

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -15,7 +15,7 @@ import XReferee.SearchResult (
   SearchResult (..),
   findRefsFromGit,
  )
-import XReferee.TestUtils.API (anchor, defaultOpts, loc, ref)
+import XReferee.TestUtils.API (anchor, defaultOpts, loc', ref)
 import XReferee.TestUtils.Git (withGitRepo)
 
 spec :: Spec
@@ -29,8 +29,8 @@ spec = do
       withGitRepo files $ do
         let expected =
               SearchResult
-                { anchors = Map.fromList [anchor "foo" [loc "python/a/b/foo_anchor.py" 1 11 20]]
-                , references = Map.fromList [ref "foo" [loc "javascript/c/d/foo_ref.js" 1 15 24]]
+                { anchors = Map.fromList [anchor "foo" [loc' "python/a/b/foo_anchor.py" 1 (11, 20)]]
+                , references = Map.fromList [ref "foo" [loc' "javascript/c/d/foo_ref.js" 1 (15, 24)]]
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
 
@@ -44,13 +44,13 @@ spec = do
               SearchResult
                 { anchors =
                     Map.fromList
-                      [ anchor "foo" [loc "python/a/b/foo_anchor.py" 1 11 20, loc "python/a/b/foo_anchor.py" 1 22 31]
-                      , anchor "foo2" [loc "python/a/b/foo_anchor.py" 1 33 43]
+                      [ anchor "foo" [loc' "python/a/b/foo_anchor.py" 1 (11, 20), loc' "python/a/b/foo_anchor.py" 1 (22, 31)]
+                      , anchor "foo2" [loc' "python/a/b/foo_anchor.py" 1 (33, 43)]
                       ]
                 , references =
                     Map.fromList
-                      [ ref "foo" [loc "javascript/c/d/foo_ref.js" 1 15 24, loc "javascript/c/d/foo_ref.js" 1 26 35]
-                      , ref "foo2" [loc "javascript/c/d/foo_ref.js" 1 37 47]
+                      [ ref "foo" [loc' "javascript/c/d/foo_ref.js" 1 (15, 24), loc' "javascript/c/d/foo_ref.js" 1 (26, 35)]
+                      , ref "foo2" [loc' "javascript/c/d/foo_ref.js" 1 (37, 47)]
                       ]
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
@@ -71,8 +71,8 @@ spec = do
               SearchResult
                 { anchors =
                     Map.fromList
-                      [ anchor "test1" [loc "foo:49:.txt" 1 1 12]
-                      , anchor "test2" [loc "foo\\.txt" 1 1 12]
+                      [ anchor "test1" [loc' "foo:49:.txt" 1 (1, 12)]
+                      , anchor "test2" [loc' "foo\\.txt" 1 (1, 12)]
                       ]
                 , references = mempty
                 }
@@ -86,8 +86,8 @@ spec = do
       withGitRepo files $ do
         let expected =
               SearchResult
-                { anchors = Map.fromList [anchor "foo" [loc "python/a/b/foo_anchor.py" 1 11 20]]
-                , references = Map.fromList [ref "foo" [loc "javascript/c/d/foo_ref.js" 1 15 24]]
+                { anchors = Map.fromList [anchor "foo" [loc' "python/a/b/foo_anchor.py" 1 (11, 20)]]
+                , references = Map.fromList [ref "foo" [loc' "javascript/c/d/foo_ref.js" 1 (15, 24)]]
                 }
         withCurrentDirectory "python/a/b/" $
           findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -29,8 +29,8 @@ spec = do
       withGitRepo files $ do
         let expected =
               SearchResult
-                { anchors = Map.fromList [anchor "foo" [loc "python/a/b/foo_anchor.py" 1]]
-                , references = Map.fromList [ref "foo" [loc "javascript/c/d/foo_ref.js" 1]]
+                { anchors = Map.fromList [anchor "foo" [loc "python/a/b/foo_anchor.py" 1 11 20]]
+                , references = Map.fromList [ref "foo" [loc "javascript/c/d/foo_ref.js" 1 15 24]]
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
 
@@ -44,13 +44,13 @@ spec = do
               SearchResult
                 { anchors =
                     Map.fromList
-                      [ anchor "foo" [loc "python/a/b/foo_anchor.py" 1, loc "python/a/b/foo_anchor.py" 1]
-                      , anchor "foo2" [loc "python/a/b/foo_anchor.py" 1]
+                      [ anchor "foo" [loc "python/a/b/foo_anchor.py" 1 11 20, loc "python/a/b/foo_anchor.py" 1 22 31]
+                      , anchor "foo2" [loc "python/a/b/foo_anchor.py" 1 33 43]
                       ]
                 , references =
                     Map.fromList
-                      [ ref "foo" [loc "javascript/c/d/foo_ref.js" 1, loc "javascript/c/d/foo_ref.js" 1]
-                      , ref "foo2" [loc "javascript/c/d/foo_ref.js" 1]
+                      [ ref "foo" [loc "javascript/c/d/foo_ref.js" 1 15 24, loc "javascript/c/d/foo_ref.js" 1 26 35]
+                      , ref "foo2" [loc "javascript/c/d/foo_ref.js" 1 37 47]
                       ]
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
@@ -71,8 +71,8 @@ spec = do
               SearchResult
                 { anchors =
                     Map.fromList
-                      [ anchor "test1" [loc "foo:49:.txt" 1]
-                      , anchor "test2" [loc "foo\\.txt" 1]
+                      [ anchor "test1" [loc "foo:49:.txt" 1 1 12]
+                      , anchor "test2" [loc "foo\\.txt" 1 1 12]
                       ]
                 , references = mempty
                 }
@@ -86,8 +86,8 @@ spec = do
       withGitRepo files $ do
         let expected =
               SearchResult
-                { anchors = Map.fromList [anchor "foo" [loc "python/a/b/foo_anchor.py" 1]]
-                , references = Map.fromList [ref "foo" [loc "javascript/c/d/foo_ref.js" 1]]
+                { anchors = Map.fromList [anchor "foo" [loc "python/a/b/foo_anchor.py" 1 11 20]]
+                , references = Map.fromList [ref "foo" [loc "javascript/c/d/foo_ref.js" 1 15 24]]
                 }
         withCurrentDirectory "python/a/b/" $
           findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)

--- a/test/XReferee/TestUtils/API.hs
+++ b/test/XReferee/TestUtils/API.hs
@@ -5,6 +5,7 @@ module XReferee.TestUtils.API (
   anchor,
   ref,
   loc,
+  loc',
 ) where
 
 import Data.Text (Text)
@@ -28,8 +29,14 @@ anchor name locs = (Anchor name, locs)
 ref :: Text -> [LabelLoc] -> (Reference, [LabelLoc])
 ref name locs = (Reference name, locs)
 
-loc :: FilePath -> Int -> Int -> Int -> LabelLoc
-loc filepath lineNum startCol endCol =
+loc :: FilePath -> Int -> LabelLoc
+loc filepath lineNum =
+  loc' filepath lineNum dummyColumnRange
+  where
+    dummyColumnRange = (0, 0)
+
+loc' :: FilePath -> Int -> (Int, Int) -> LabelLoc
+loc' filepath lineNum (startCol, endCol) =
   LabelLoc
     { filepath
     , lineNum

--- a/test/XReferee/TestUtils/API.hs
+++ b/test/XReferee/TestUtils/API.hs
@@ -10,6 +10,7 @@ module XReferee.TestUtils.API (
 import Data.Text (Text)
 import XReferee.SearchResult (
   Anchor (..),
+  ColumnRange (..),
   LabelLoc (..),
   Reference (..),
   SearchOpts (..),
@@ -27,5 +28,10 @@ anchor name locs = (Anchor name, locs)
 ref :: Text -> [LabelLoc] -> (Reference, [LabelLoc])
 ref name locs = (Reference name, locs)
 
-loc :: FilePath -> Int -> LabelLoc
-loc = LabelLoc
+loc :: FilePath -> Int -> Int -> Int -> LabelLoc
+loc filepath lineNum startCol endCol =
+  LabelLoc
+    { filepath
+    , lineNum
+    , columnRange = ColumnRange{start = startCol, end = endCol}
+    }

--- a/test/XReferee/TestUtils/Fixtures.hs
+++ b/test/XReferee/TestUtils/Fixtures.hs
@@ -23,6 +23,7 @@ data Loc = Loc
   { file :: FilePath
   , lineNum :: Int
   }
+  deriving (Eq, Ord)
 
 data Fixture = Fixture
   { anchors :: Map Text Loc


### PR DESCRIPTION
While working on https://github.com/dcastro/lsp-xreferee, I had to:

1. change `LabelLoc` to also keep track of column ranges.
2. export `parseLabels`

Note that I didn't include the column ranges in the `Report` itself (so the integration tests weren't affected), though I can do that if you wish.
