### PR TITLE
Include untracked files

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -34,6 +34,12 @@ cliOptions =
           , Opt.short 'I'
           , Opt.help "Git glob specs for paths to ignore"
           ]
+      includeUntracked <-
+        Opt.switch . mconcat $
+          [ Opt.long "include-untracked"
+          , Opt.short 'U'
+          , Opt.help "Include git untracked files in the search"
+          ]
       pure SearchOpts{..}
 
 {----- Entrypoint -----}

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -31,6 +31,7 @@ import Text.Read (readMaybe)
 
 data SearchOpts = SearchOpts
   { ignores :: [Text]
+  , includeUntracked :: Bool
   }
 
 -- Customize? https://github.com/brandonchinn178/xreferee/issues/11
@@ -90,7 +91,7 @@ findRefsFromGit opts = do
           [ ["grep"]
           , ["-z", "--full-name", "--line-number", "--column"]
           , ["-I"] -- ignore binary files
-          , ["--untracked"] -- include untracked files
+          , ["--untracked" | opts.includeUntracked] -- include untracked files
           , ["--fixed-strings", "-e", Text.unpack anchorStart, "-e", Text.unpack refStart]
           , ["--"]
           , [":/"]

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -90,6 +90,7 @@ findRefsFromGit opts = do
           [ ["grep"]
           , ["-z", "--full-name", "--line-number", "--column"]
           , ["-I"] -- ignore binary files
+          , ["--untracked"] -- include untracked files
           , ["--fixed-strings", "-e", Text.unpack anchorStart, "-e", Text.unpack refStart]
           , ["--"]
           , [":/"]

--- a/test/XReferee/TestUtils/API.hs
+++ b/test/XReferee/TestUtils/API.hs
@@ -19,6 +19,7 @@ defaultOpts :: SearchOpts
 defaultOpts =
   SearchOpts
     { ignores = []
+    , includeUntracked = False
     }
 
 anchor :: Text -> [LabelLoc] -> (Anchor, [LabelLoc])


### PR DESCRIPTION
While working on https://github.com/dcastro/lsp-xreferee, I had to enable `--untracked` while calling `git grep`.

When using `xreferee` in the context of an editor extension (as opposed to using it in e.g. a CI), the user will most likely want xreferee to detect changes done to files not yet tracked by git.

