### PR TITLE
Rewrite parser with lazy bytestring + elemIndex

### DIFF
--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -10,24 +12,27 @@ module XReferee.SearchResult (
   Reference (..),
   Label (..),
   ColumnRange (..),
+  ColNum,
   LabelLoc (..),
   findRefsFromGit,
   parseLabels,
 ) where
 
-import Control.Applicative ((<|>))
 import Control.DeepSeq (NFData (..), ($!!))
 import Control.Exception (evaluate)
 import Control.Monad (guard, when)
+import Data.Bitraversable (bitraverse)
 import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
+import Data.Int (Int64)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
+import GHC.Records (HasField (..))
 import System.Exit (ExitCode (..))
 import System.IO qualified as IO
 import System.Process qualified as Process
@@ -86,9 +91,11 @@ data LabelLoc = LabelLoc
   }
   deriving (Show, Eq, Ord)
 
+type ColNum = Int
+
 data ColumnRange = ColumnRange
-  { start :: Int
-  , end :: Int
+  { start :: ColNum
+  , end :: ColNum
   }
   deriving (Show, Eq, Ord)
 
@@ -145,50 +152,96 @@ findRefsFromGit opts = do
           , references = Map.fromListWith (<>) [(ref, [mkLoc range]) | (ref, range) <- references]
           }
 
--- | Parse all labels from the given text.
 parseLabels ::
-  -- | The text to parse for labels.
   LazyByteString ->
-  -- | The column number of the first label in the input text. Used to calculate the column numbers for the labels.
-  Int ->
+  ColNum ->
   ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
-parseLabels text col =
+parseLabels s0 col0 =
   partitionUnfoldr parseSomeMarker $
-    ( LBS.drop (fromIntegral col - 1) text
-    , col
-    )
+    ParseState
+      { str = LBS.drop (fromIntegral col0 - 1) s0
+      , col = col0
+      }
   where
-    markerStarts = map (LBS.head . toLBS) [anchorStart, refStart]
     toLBS = LBS.fromStrict . Text.encodeUtf8
     toText = Text.decodeUtf8 . LBS.toStrict
 
-    parseSomeMarker (s0, col0) =
-      -- Remove the prefix before the next marker, and update the column number accordingly.
-      let (prefix, s1) = LBS.break (`elem` markerStarts) s0
-          col1 = col0 + fromIntegral (LBS.length prefix)
-       in case (Left <$> parseAnchor s1) <|> (Right <$> parseRef s1) of
-            Just (Left (name, s2)) ->
-              let markerLen = Text.length anchorStart + fromIntegral (LBS.length name) + Text.length anchorEnd
-                  columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
-                  -- Advance the column number to match the remaining string `s2`
-                  col2 = col1 + markerLen
-               in Just (Left (Anchor (toText name), columnRange), (s2, col2))
-            Just (Right (name, s2)) ->
-              let markerLen = Text.length refStart + fromIntegral (LBS.length name) + Text.length refEnd
-                  columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
-                  col2 = col1 + markerLen
-               in Just (Right (Reference (toText name), columnRange), (s2, col2))
-            Nothing
-              | LBS.null s1 -> Nothing
-              | otherwise -> parseSomeMarker (LBS.drop 1 s1, col1 + 1)
+    anchorStartBS = toLBS anchorStart
+    anchorEndBS = toLBS anchorEnd
+    refStartBS = toLBS refStart
+    refEndBS = toLBS refEnd
 
-    parseAnchor = parseMarker anchorStart anchorEnd
-    parseRef = parseMarker refStart refEnd
-    parseMarker start end s0 = do
-      s1 <- LBS.stripPrefix (toLBS start) s0
-      (name, s2) <- splitOnce (toLBS end) s1
+    -- TODO: When anchorStart/refStart are customizable, make sure to validate
+    -- that they're non-empty
+    anchorStartChar = LBS.head anchorStartBS
+    refStartChar = LBS.head refStartBS
+
+    parseSomeMarker state = do
+      let anchorIndex = LBS.elemIndex anchorStartChar state.str
+          refIndex = LBS.elemIndex refStartChar state.str
+      case minMaybe anchorIndex refIndex of
+        -- No more matches; stop the loop
+        Nothing -> Nothing
+        -- Found an anchor or ref
+        Just eIndex -> do
+          case bitraverse (parseAnchor state) (parseRef state) eIndex of
+            -- Successful parse; return
+            Just eResult -> Just $ distributeEither eResult
+            -- False positive; try again
+            Nothing -> do
+              let n = fromEither eIndex + 1
+              parseSomeMarker (state.drop n)
+      where
+        fromEither = either id id
+
+        distributeEither :: Either (a, c) (b, c) -> (Either a b, c)
+        distributeEither = \case
+          Left (a, c) -> (Left a, c)
+          Right (b, c) -> (Right b, c)
+
+    parseAnchor = parseMarker (Anchor, anchorStartBS, anchorEndBS)
+    parseRef = parseMarker (Reference, refStartBS, refEndBS)
+    parseMarker (f, start, end) state0 index = do
+      let state1 = state0.drop index
+      state2 <- state1.stripPrefix start
+      (name, state3) <- state2.splitOnce end
       guard $ (not . LBS.null) name
-      pure (name, s2)
+      let marker = (f . toText) name
+          range =
+            ColumnRange
+              { start = state1.col
+              , end = state3.col - 1
+              }
+      Just ((marker, range), state3)
+
+data ParseState = ParseState
+  { str :: !LazyByteString
+  , col :: !ColNum
+  }
+instance HasField "drop" ParseState (Int64 -> ParseState) where
+  getField state n =
+    ParseState
+      { str = LBS.drop n state.str
+      , col = state.col + fromIntegral n
+      }
+instance HasField "stripPrefix" ParseState (LazyByteString -> Maybe ParseState) where
+  getField state pre = go <$> LBS.stripPrefix pre state.str
+    where
+      go str' =
+        ParseState
+          { str = str'
+          , col = state.col + fromIntegral (LBS.length pre)
+          }
+instance HasField "splitOnce" ParseState (LazyByteString -> Maybe (LazyByteString, ParseState)) where
+  getField state delim = go <$> splitOnce delim state.str
+    where
+      go (res, str') =
+        let state' =
+              ParseState
+                { str = str'
+                , col = state.col + fromIntegral (LBS.length res + LBS.length delim)
+                }
+         in (res, state')
 
 {----- Utilities -----}
 
@@ -200,6 +253,20 @@ partitionUnfoldr f =
           Just (Right b, s') -> go as (b : bs) s'
           Nothing -> (as, bs)
    in go [] []
+
+{- | Return the smaller of the two.
+
+>>> minMaybe (Just 1) (Just 3) == Just (Left 1)
+>>> minMaybe (Just 3) (Just 1) == Just (Right 1)
+>>> minMaybe (Just 1) Nothing  == Just (Left 1)
+>>> minMaybe Nothing Nothing   == Nothing
+-}
+minMaybe :: (Ord a) => Maybe a -> Maybe a -> Maybe (Either a a)
+minMaybe = \cases
+  (Just a) (Just b) -> Just $ if a < b then Left a else Right b
+  (Just a) Nothing -> Just (Left a)
+  Nothing (Just b) -> Just (Right b)
+  Nothing Nothing -> Nothing
 
 {- | Split on the given delimiter
 

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -19,13 +19,15 @@ import Control.Applicative ((<|>))
 import Control.DeepSeq (NFData (..), ($!!))
 import Control.Exception (evaluate)
 import Control.Monad (guard, when)
+import Data.ByteString.Lazy (LazyByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Text.Lazy qualified as TextL
-import Data.Text.Lazy.IO qualified as TextL
+import Data.Text.Encoding qualified as Text
 import System.Exit (ExitCode (..))
 import System.IO qualified as IO
 import System.Process qualified as Process
@@ -115,24 +117,25 @@ findRefsFromGit opts = do
           , Process.std_err = Process.CreatePipe
           }
   Process.withCreateProcess proc $ \_ stdoutHandle stderrHandle ph -> do
-    stdout <- maybe (pure "") TextL.hGetContents stdoutHandle
-    result <- evaluate $!! mconcat . map parseLine . TextL.lines $ stdout
+    stdout <- maybe (pure "") LBS.hGetContents stdoutHandle
+    result <- evaluate $!! mconcat . map parseLine . LBS.Char8.lines $ stdout
     code <- Process.waitForProcess ph
-    stderr <- maybe (pure "") TextL.hGetContents stderrHandle
-    TextL.hPutStr IO.stderr stderr
-    when (code /= ExitSuccess && (not . TextL.null) stderr) $
+    stderr <- maybe (pure "") LBS.hGetContents stderrHandle
+    LBS.hPutStr IO.stderr stderr
+    when (code /= ExitSuccess && (not . LBS.null) stderr) $
       -- TODO: Proper error?
       errorWithoutStackTrace "git grep failed"
     pure result
   where
     parseLine line = fromMaybe mempty $ do
-      [filepath, lineNumStr, colNumStr, rest] <- pure $ TextL.splitOn "\0" line
-      lineNum <- readMaybe $ TextL.unpack lineNumStr
-      colNum <- readMaybe $ TextL.unpack colNumStr
+      -- Split on \NUL characters
+      [filepath, lineNumStr, colNumStr, rest] <- pure $ LBS.split 0 line
+      lineNum <- readMaybe $ LBS.Char8.unpack lineNumStr
+      colNum <- readMaybe $ LBS.Char8.unpack colNumStr
       let (anchors, references) = parseLabels rest colNum
           mkLoc columnRange =
             LabelLoc
-              { filepath = TextL.unpack filepath
+              { filepath = LBS.Char8.unpack filepath
               , lineNum
               , columnRange
               }
@@ -145,7 +148,7 @@ findRefsFromGit opts = do
 -- | Parse all labels from the given text.
 parseLabels ::
   -- | The text to parse for labels.
-  TextL.Text ->
+  LazyByteString ->
   -- | The column number of the first label in the input text. Used to calculate the column numbers for the labels.
   Int ->
   ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
@@ -153,45 +156,64 @@ parseLabels text col =
   parseSomeMarker
     []
     []
-    (TextL.drop (fromIntegral col - 1) text)
+    (LBS.drop (fromIntegral col - 1) text)
     col
   where
-    markerStarts = map Text.head [anchorStart, refStart]
+    markerStarts = map (LBS.head . toLBS) [anchorStart, refStart]
+    toLBS = LBS.fromStrict . Text.encodeUtf8
+    toText = Text.decodeUtf8 . LBS.toStrict
 
     parseSomeMarker ::
       [(Anchor, ColumnRange)] ->
       [(Reference, ColumnRange)] ->
-      TextL.Text ->
+      LazyByteString ->
       Int ->
       ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
     parseSomeMarker anchors refs s0 col0 =
       -- Remove the prefix before the next marker, and update the column number accordingly.
-      let (prefix, s1) = TextL.break (`elem` markerStarts) s0
-          col1 = col0 + fromIntegral (TextL.length prefix)
+      let (prefix, s1) = LBS.break (`elem` markerStarts) s0
+          col1 = col0 + fromIntegral (LBS.length prefix)
        in case (Left <$> parseAnchor s1) <|> (Right <$> parseRef s1) of
             Just (Left (name, s2)) ->
-              let markerLen = Text.length anchorStart + fromIntegral (TextL.length name) + Text.length anchorEnd
+              let markerLen = Text.length anchorStart + fromIntegral (LBS.length name) + Text.length anchorEnd
                   columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
                   -- Advance the column number to match the remaining string `s2`
                   col2 = col1 + markerLen
-               in parseSomeMarker ((Anchor (TextL.toStrict name), columnRange) : anchors) refs s2 col2
+               in parseSomeMarker ((Anchor (toText name), columnRange) : anchors) refs s2 col2
             Just (Right (name, s2)) ->
-              let markerLen = Text.length refStart + fromIntegral (TextL.length name) + Text.length refEnd
+              let markerLen = Text.length refStart + fromIntegral (LBS.length name) + Text.length refEnd
                   columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
                   col2 = col1 + markerLen
-               in parseSomeMarker anchors ((Reference (TextL.toStrict name), columnRange) : refs) s2 col2
+               in parseSomeMarker anchors ((Reference (toText name), columnRange) : refs) s2 col2
             Nothing
-              | TextL.null s1 -> (anchors, refs)
-              | otherwise -> parseSomeMarker anchors refs (TextL.drop 1 s1) (col1 + 1)
+              | LBS.null s1 -> (anchors, refs)
+              | otherwise -> parseSomeMarker anchors refs (LBS.drop 1 s1) (col1 + 1)
 
     parseAnchor = parseMarker anchorStart anchorEnd
     parseRef = parseMarker refStart refEnd
     parseMarker start end s0 = do
-      s1 <- TextL.stripPrefix (TextL.fromStrict start) s0
-      (name, s2) <- breakOn' (TextL.fromStrict end) s1
-      guard $ (not . TextL.null) name
+      s1 <- LBS.stripPrefix (toLBS start) s0
+      (name, s2) <- splitOnce (toLBS end) s1
+      guard $ (not . LBS.null) name
       pure (name, s2)
 
-    -- Same as breakOn, except returns Nothing if the delim isn't found, and
-    -- the snd string doesn't start with the delim.
-    breakOn' delim = traverse (TextL.stripPrefix delim) . TextL.breakOn delim
+{----- Utilities -----}
+
+{- | Split on the given delimiter
+
+>>> splitOnce "::" "a" == Nothing
+>>> splitOnce "::" "a::b::c" == Just ("a", "b::c")
+-}
+splitOnce :: LazyByteString -> LazyByteString -> Maybe (LazyByteString, LazyByteString)
+splitOnce delim =
+  let delimChar = LBS.head delim
+      go s =
+        case LBS.elemIndex delimChar s of
+          -- Delimiter not found
+          Nothing -> Nothing
+          Just i
+            -- Found delimiter
+            | Just s' <- LBS.stripPrefix delim (LBS.drop i s) -> Just (LBS.take i s, s')
+            -- False positive, try again
+            | otherwise -> go (LBS.drop (i + 1) s)
+   in go

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -153,23 +153,16 @@ parseLabels ::
   Int ->
   ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
 parseLabels text col =
-  parseSomeMarker
-    []
-    []
-    (LBS.drop (fromIntegral col - 1) text)
-    col
+  partitionUnfoldr parseSomeMarker $
+    ( LBS.drop (fromIntegral col - 1) text
+    , col
+    )
   where
     markerStarts = map (LBS.head . toLBS) [anchorStart, refStart]
     toLBS = LBS.fromStrict . Text.encodeUtf8
     toText = Text.decodeUtf8 . LBS.toStrict
 
-    parseSomeMarker ::
-      [(Anchor, ColumnRange)] ->
-      [(Reference, ColumnRange)] ->
-      LazyByteString ->
-      Int ->
-      ([(Anchor, ColumnRange)], [(Reference, ColumnRange)])
-    parseSomeMarker anchors refs s0 col0 =
+    parseSomeMarker (s0, col0) =
       -- Remove the prefix before the next marker, and update the column number accordingly.
       let (prefix, s1) = LBS.break (`elem` markerStarts) s0
           col1 = col0 + fromIntegral (LBS.length prefix)
@@ -179,15 +172,15 @@ parseLabels text col =
                   columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
                   -- Advance the column number to match the remaining string `s2`
                   col2 = col1 + markerLen
-               in parseSomeMarker ((Anchor (toText name), columnRange) : anchors) refs s2 col2
+               in Just (Left (Anchor (toText name), columnRange), (s2, col2))
             Just (Right (name, s2)) ->
               let markerLen = Text.length refStart + fromIntegral (LBS.length name) + Text.length refEnd
                   columnRange = ColumnRange{start = col1, end = col1 + markerLen - 1}
                   col2 = col1 + markerLen
-               in parseSomeMarker anchors ((Reference (toText name), columnRange) : refs) s2 col2
+               in Just (Right (Reference (toText name), columnRange), (s2, col2))
             Nothing
-              | LBS.null s1 -> (anchors, refs)
-              | otherwise -> parseSomeMarker anchors refs (LBS.drop 1 s1) (col1 + 1)
+              | LBS.null s1 -> Nothing
+              | otherwise -> parseSomeMarker (LBS.drop 1 s1, col1 + 1)
 
     parseAnchor = parseMarker anchorStart anchorEnd
     parseRef = parseMarker refStart refEnd
@@ -198,6 +191,15 @@ parseLabels text col =
       pure (name, s2)
 
 {----- Utilities -----}
+
+partitionUnfoldr :: (s -> Maybe (Either a b, s)) -> s -> ([a], [b])
+partitionUnfoldr f =
+  let go !as !bs !s =
+        case f s of
+          Just (Left a, s') -> go (a : as) bs s'
+          Just (Right b, s') -> go as (b : bs) s'
+          Nothing -> (as, bs)
+   in go [] []
 
 {- | Split on the given delimiter
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-snapshot: nightly-2025-12-10
+snapshot: nightly-2026-04-16
 
 ghc-options:
   "$everything": -O2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 624dc86546207bcf970522795cb2344c36c06a7d94b9cb533c825d8d84ff9161
-    size: 712617
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2025/12/10.yaml
-  original: nightly-2025-12-10
+    sha256: b409b328286978de8e84b2a69fcd18030012ddfde94af5d635578e42b01d9a27
+    size: 738341
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2026/4/16.yaml
+  original: nightly-2026-04-16

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -38,6 +38,8 @@ spec = do
       let files =
             [ ("python/a/b/foo_anchor.py", "FOO = 1 # #(ref:foo) #(ref:foo) #(ref:foo2)")
             , ("javascript/c/d/foo_ref.js", "const FOO = 1 @(ref:foo) @(ref:foo) @(ref:foo2)")
+            , ("mixed_anchor_first.sh", "FOO=1 # #(ref:mixed1) @(ref:mixed2)")
+            , ("mixed_ref_first.sh", "FOO=1 # @(ref:mixed1) #(ref:mixed2)")
             ]
       withGitRepo files $ do
         let expected =
@@ -46,11 +48,15 @@ spec = do
                     Map.fromList
                       [ anchor "foo" [loc' "python/a/b/foo_anchor.py" 1 (11, 20), loc' "python/a/b/foo_anchor.py" 1 (22, 31)]
                       , anchor "foo2" [loc' "python/a/b/foo_anchor.py" 1 (33, 43)]
+                      , anchor "mixed1" [loc' "mixed_anchor_first.sh" 1 (9, 21)]
+                      , anchor "mixed2" [loc' "mixed_ref_first.sh" 1 (23, 35)]
                       ]
                 , references =
                     Map.fromList
                       [ ref "foo" [loc' "javascript/c/d/foo_ref.js" 1 (15, 24), loc' "javascript/c/d/foo_ref.js" 1 (26, 35)]
                       , ref "foo2" [loc' "javascript/c/d/foo_ref.js" 1 (37, 47)]
+                      , ref "mixed1" [loc' "mixed_ref_first.sh" 1 (9, 21)]
+                      , ref "mixed2" [loc' "mixed_anchor_first.sh" 1 (23, 35)]
                       ]
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -28,6 +28,7 @@ library
     XReferee.SearchResult
   build-depends:
       base < 5
+    , bytestring
     , containers
     , deepseq
     , process


### PR DESCRIPTION
Blog post: https://brandonchinn178.github.io/posts/2026/04/17/optimizing-xreferee-with-elemindex/

5x faster on extremely long lines, tested against a binary built from the "Bump resolver" commit.
```
Benchmark 1: ./xreferee-old
  Time (mean ± σ):      7.243 s ±  0.021 s    [User: 6.874 s, System: 0.895 s]
  Range (min … max):    7.211 s …  7.276 s    10 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: ./xreferee-new
  Time (mean ± σ):      1.253 s ±  0.009 s    [User: 1.365 s, System: 0.308 s]
  Range (min … max):    1.241 s …  1.268 s    10 runs

  Warning: Ignoring non-zero exit code.

Summary
  ./xreferee-new ran
    5.78 ± 0.05 times faster than ./xreferee-old
```

This only shows up for files with long lines; excluding `data/` only shows a hair of an improvement.

```
Benchmark 1: ./xreferee-old -Idata
  Time (mean ± σ):      16.3 ms ±   0.7 ms    [User: 5.3 ms, System: 5.5 ms]
  Range (min … max):    14.0 ms …  17.1 ms    156 runs

  Warning: Ignoring non-zero exit code.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: ./xreferee-new -Idata
  Time (mean ± σ):      15.8 ms ±   0.8 ms    [User: 5.2 ms, System: 5.4 ms]
  Range (min … max):    13.8 ms …  16.8 ms    154 runs

  Warning: Ignoring non-zero exit code.

Summary
  ./xreferee-new -Idata ran
    1.03 ± 0.07 times faster than ./xreferee-old -Idata
```

`LBS.elemIndex` uses `memchr`, which is much faster. Since our markers are only ASCII characters, it's safe to parse with ByteString, and this is actually safer since we wouldn't get decoding errors when decoding non-utf-8 git grep output to Text.