### PR TITLE
ColumnRanges: unicode support

### DIFF
--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -120,7 +120,15 @@ data LabelLoc = LabelLoc
   }
   deriving (Show, Eq, Ord)
 
+-- | 1-based line number.
 type LineNum = Int
+
+{- | 1-based column number.
+
+The column number is based on UTF-16 code units, which is how offsets
+are calculated by default in the LSP protocol.
+See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocuments
+-}
 type ColNum = Int
 
 data ColumnRange = ColumnRange

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
@@ -26,7 +25,6 @@ module XReferee.SearchResult (
 
   -- * Internal API
   parseLabels,
-  utf16Length,
 ) where
 
 import Control.DeepSeq (NFData (..), ($!!))
@@ -49,6 +47,7 @@ import System.Exit (ExitCode (..))
 import System.IO qualified as IO
 import System.Process qualified as Process
 import Text.Read (readMaybe)
+import XReferee.Utils.Utf16 (utf16Length)
 
 data SearchOpts = SearchOpts
   { delims :: MarkerDelims
@@ -369,25 +368,3 @@ splitOnce delim =
             -- False positive, try again
             | otherwise -> go (LBS.drop (i + 1) s)
    in go
-
--- | Takes a UTF-8-encoded bytestring and counts the number of UTF-16 code units.
-utf16Length :: LazyByteString -> ColNum
-utf16Length = LBS.foldl' (\n w -> n + codeUnits w) 0
-  where
-    -- In UTF-16, codepoints from the Basic Multilingual Plane (BMP) are encoded as a single code unit,
-    -- while codepoints outside the BMP are encoded as a surrogate pair, which counts as two code units.
-    --
-    -- This function goes through a UTF-8 encoded bytestring, see: https://en.wikipedia.org/wiki/UTF-8#Description
-    -- If it finds a codepoint from the BMP, it adds 1 to the counter.
-    -- If it finds a codepoint outside the BMP, it adds 2 to the counter.
-    codeUnits w
-      -- Single byte codepoint
-      | w < 0b10000000 = 1
-      -- Continuation byte
-      | w < 0b11000000 = 0
-      -- A byte marking the sequence of a 2/3 byte codepoint, up to U+FFFF.
-      -- Such codepoints belong to the BMP, so they correspond to 1x UTF-16 code unit.
-      | w < 0b11110000 = 1
-      -- A byte marking the sequence of a 4-byte codepoint, U+10000 and above.
-      -- Such codepoints are outside the BMP and are encoded as a surrogate pair, counting as 2x UTF-16 code units.
-      | otherwise = 2

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
@@ -261,17 +262,18 @@ data ParseState = ParseState
   }
 instance HasField "drop" ParseState (Int64 -> ParseState) where
   getField state n =
-    ParseState
-      { str = LBS.drop n state.str
-      , col = state.col + fromIntegral n
-      }
+    let (before, after) = LBS.splitAt n state.str
+     in ParseState
+          { str = after
+          , col = state.col + utf16Length before
+          }
 instance HasField "stripPrefix" ParseState (LazyByteString -> Maybe ParseState) where
   getField state pre = go <$> LBS.stripPrefix pre state.str
     where
       go str' =
         ParseState
           { str = str'
-          , col = state.col + fromIntegral (LBS.length pre)
+          , col = state.col + utf16Length pre
           }
 instance HasField "splitOnce" ParseState (LazyByteString -> Maybe (LazyByteString, ParseState)) where
   getField state delim = go <$> splitOnce delim state.str
@@ -280,7 +282,7 @@ instance HasField "splitOnce" ParseState (LazyByteString -> Maybe (LazyByteStrin
         let state' =
               ParseState
                 { str = str'
-                , col = state.col + fromIntegral (LBS.length res + LBS.length delim)
+                , col = state.col + utf16Length res + utf16Length delim
                 }
          in (res, state')
 
@@ -358,3 +360,25 @@ splitOnce delim =
             -- False positive, try again
             | otherwise -> go (LBS.drop (i + 1) s)
    in go
+
+-- | Takes a UTF-8-encoded bytestring and counts the number of UTF-16 code units.
+utf16Length :: LazyByteString -> ColNum
+utf16Length = LBS.foldl' (\n w -> n + codeUnits w) 0
+  where
+    -- In UTF-16, codepoints from the Basic Multilingual Plane (BMP) are encoded as a single code unit,
+    -- while codepoints outside the BMP are encoded as a surrogate pair, which counts as two code units.
+    --
+    -- This function goes through a UTF-8 encoded bytestring, see: https://en.wikipedia.org/wiki/UTF-8#Description
+    -- If it finds a codepoint from the BMP, it adds 1 to the counter.
+    -- If it finds a codepoint outside the BMP, it adds 2 to the counter.
+    codeUnits w
+      -- Single byte codepoint
+      | w < 0b10000000 = 1
+      -- Continuation byte
+      | w < 0b11000000 = 0
+      -- A byte marking the sequence of a 2/3 byte codepoint, up to U+FFFF.
+      -- Such codepoints belong to the BMP, so they correspond to 1x UTF-16 code unit.
+      | w < 0b11110000 = 1
+      -- A byte marking the sequence of a 4-byte codepoint, U+10000 and above.
+      -- Such codepoints are outside the BMP and are encoded as a surrogate pair, counting as 2x UTF-16 code units.
+      | otherwise = 2

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -26,6 +26,7 @@ module XReferee.SearchResult (
 
   -- * Internal API
   parseLabels,
+  utf16Length,
 ) where
 
 import Control.DeepSeq (NFData (..), ($!!))

--- a/src/XReferee/Utils/Utf16.hs
+++ b/src/XReferee/Utils/Utf16.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE BinaryLiterals #-}
+
+module XReferee.Utils.Utf16 (
+  utf16Length,
+) where
+
+import Data.ByteString.Lazy (LazyByteString)
+import Data.ByteString.Lazy qualified as LBS
+
+-- | Takes a UTF-8-encoded bytestring and counts the number of UTF-16 code units.
+utf16Length :: LazyByteString -> Int
+utf16Length = LBS.foldl' (\n w -> n + codeUnits w) 0
+  where
+    -- In UTF-16, codepoints from the Basic Multilingual Plane (BMP) are encoded as a single code unit,
+    -- while codepoints outside the BMP are encoded as a surrogate pair, which counts as two code units.
+    --
+    -- This function goes through a UTF-8 encoded bytestring, see: https://en.wikipedia.org/wiki/UTF-8#Description
+    -- If it finds a codepoint from the BMP, it adds 1 to the counter.
+    -- If it finds a codepoint outside the BMP, it adds 2 to the counter.
+    codeUnits w
+      -- Single byte codepoint
+      | w < 0b10000000 = 1
+      -- Continuation byte
+      | w < 0b11000000 = 0
+      -- A byte marking the sequence of a 2/3 byte codepoint, up to U+FFFF.
+      -- Such codepoints belong to the BMP, so they correspond to 1x UTF-16 code unit.
+      | w < 0b11110000 = 1
+      -- A byte marking the sequence of a 4-byte codepoint, U+10000 and above.
+      -- Such codepoints are outside the BMP and are encoded as a surrogate pair, counting as 2x UTF-16 code units.
+      | otherwise = 2

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -5,9 +5,14 @@
 
 module XReferee.SearchResultSpec (spec) where
 
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Map qualified as Map
+import Data.Text.Encoding qualified as TE
 import Skeletest
 import Skeletest.Predicate qualified as P
+import Skeletest.Prop.Gen qualified as Gen
+import Skeletest.Prop.Range qualified as Range
 import System.Directory (
   withCurrentDirectory,
  )
@@ -15,6 +20,7 @@ import XReferee.SearchResult (
   SearchOpts (..),
   SearchResult (..),
   findRefsFromGit,
+  utf16Length,
  )
 import XReferee.TestUtils.API (anchor, defaultOpts, loc', ref)
 import XReferee.TestUtils.Git (withGitRepo)
@@ -140,3 +146,12 @@ spec = do
                 }
         withCurrentDirectory "python/a/b/" $
           findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
+
+  describe "utf16Length" $ do
+    prop "matches reference implementation via encodeUtf16BE" $ do
+      t <- forAll $ Gen.text (Range.linear 0 100) Gen.unicodeAll
+      let bs = LBS.fromStrict (TE.encodeUtf8 t)
+      -- 1 UTF-16 code unit = 2 bytes, so we divide the length of the encoded
+      -- bytes by 2 to get the expected number of UTF-16 code units.
+      let expected = BS.length (TE.encodeUtf16BE t) `div` 2
+      utf16Length bs `shouldBe` expected

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -5,14 +5,9 @@
 
 module XReferee.SearchResultSpec (spec) where
 
-import Data.ByteString qualified as BS
-import Data.ByteString.Lazy qualified as LBS
 import Data.Map qualified as Map
-import Data.Text.Encoding qualified as TE
 import Skeletest
 import Skeletest.Predicate qualified as P
-import Skeletest.Prop.Gen qualified as Gen
-import Skeletest.Prop.Range qualified as Range
 import System.Directory (
   withCurrentDirectory,
  )
@@ -23,7 +18,6 @@ import XReferee.SearchResult (
  )
 import XReferee.TestUtils.API (anchor, defaultOpts, loc', ref)
 import XReferee.TestUtils.Git (withGitRepo)
-import XReferee.Utils.Utf16 (utf16Length)
 
 spec :: Spec
 spec = do
@@ -100,23 +94,23 @@ spec = do
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
 
     it "counts columns as UTF-16 code units" $ do
+      {-
+        "😀" is a single codepoint (U+1F600), but is not in the BMP (Basic Multilingual Plane),
+        so it's encoded using 2 UTF-16 code units.
+
+        The family emoji "👨‍👩‍👧‍👦" is a sequence of 7 codepoints:
+          * U+1F468: 👨, 2 UTF-16 code units
+          * U+200D: ZWJ (zero-width joiner), 1 UTF-16 code units
+          * U+1F469: 👩, 2 UTF-16 code units
+          * U+200D: ZWJ, 1 UTF-16 code units
+          * U+1F467: 👧, 2 UTF-16 code units
+          * U+200D: ZWJ, 1 UTF-16 code units
+          * U+1F466: 👦, 2 UTF-16 code unitss
+        Total: 11 UTF-16 code units
+      -}
       let files =
-            -- "😀" is a single codepoint (U+1F600), but is not in the BMP (Basic Multilingual Plane),
-            -- so it's encoded using 2 UTF-16 code units.
             [ ("emoji_anchor.py", "#(ref:fo😀o)")
-            , {- The family emoji "👨‍👩‍👧‍👦" is a sequence of 7 codepoints:
-
-                * U+1F468: 👨, 2 UTF-16 code units
-                * U+200D: ZWJ (zero-width joiner), 1 UTF-16 code units
-                * U+1F469: 👩, 2 UTF-16 code units
-                * U+200D: ZWJ, 1 UTF-16 code units
-                * U+1F467: 👧, 2 UTF-16 code units
-                * U+200D: ZWJ, 1 UTF-16 code units
-                * U+1F466: 👦, 2 UTF-16 code unitss
-
-                Total: 11 UTF-16 code units
-              -}
-              ("family_anchor.py", "\x1F468\x200D\x1F469\x200D\x1F467\x200D\x1F466#(ref:bar)")
+            , ("family_anchor.py", "\x1F468\x200D\x1F469\x200D\x1F467\x200D\x1F466#(ref:bar)")
             ]
       withGitRepo files $ do
         let expected =
@@ -146,12 +140,3 @@ spec = do
                 }
         withCurrentDirectory "python/a/b/" $
           findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
-
-  describe "utf16Length" $ do
-    prop "matches reference implementation via encodeUtf16BE" $ do
-      t <- forAll $ Gen.text (Range.linear 0 100) Gen.unicodeAll
-      let bs = LBS.fromStrict (TE.encodeUtf8 t)
-      -- 1 UTF-16 code unit = 2 bytes, so we divide the length of the encoded
-      -- bytes by 2 to get the expected number of UTF-16 code units.
-      let expected = BS.length (TE.encodeUtf16BE t) `div` 2
-      utf16Length bs `shouldBe` expected

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -20,10 +20,10 @@ import XReferee.SearchResult (
   SearchOpts (..),
   SearchResult (..),
   findRefsFromGit,
-  utf16Length,
  )
 import XReferee.TestUtils.API (anchor, defaultOpts, loc', ref)
 import XReferee.TestUtils.Git (withGitRepo)
+import XReferee.Utils.Utf16 (utf16Length)
 
 spec :: Spec
 spec = do

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -93,6 +93,39 @@ spec = do
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
 
+    it "counts columns as UTF-16 code units" $ do
+      let files =
+            -- "😀" is a single codepoint (U+1F600), but is not in the BMP (Basic Multilingual Plane),
+            -- so it's encoded using 2 UTF-16 code units.
+            [ ("emoji_anchor.py", "#(ref:fo😀o)")
+            , {- The family emoji "👨‍👩‍👧‍👦" is a sequence of 7 codepoints:
+
+                * U+1F468: 👨, 2 UTF-16 code units
+                * U+200D: ZWJ (zero-width joiner), 1 UTF-16 code units
+                * U+1F469: 👩, 2 UTF-16 code units
+                * U+200D: ZWJ, 1 UTF-16 code units
+                * U+1F467: 👧, 2 UTF-16 code units
+                * U+200D: ZWJ, 1 UTF-16 code units
+                * U+1F466: 👦, 2 UTF-16 code unitss
+
+                Total: 11 UTF-16 code units
+              -}
+              ("family_anchor.py", "\x1F468\x200D\x1F469\x200D\x1F467\x200D\x1F466#(ref:bar)")
+            ]
+      withGitRepo files $ do
+        let expected =
+              SearchResult
+                { delims = defaultOpts.delims
+                , anchors =
+                    Map.fromList
+                      -- NOTE: columns are 1-based.
+                      [ anchor "fo😀o" [loc' "emoji_anchor.py" 1 (1, 12)]
+                      , anchor "bar" [loc' "family_anchor.py" 1 (12, 21)]
+                      ]
+                , references = mempty
+                }
+        findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
+
     it "finds references from subdirectory" $ do
       let files =
             [ ("python/a/b/foo_anchor.py", "FOO = 1 # #(ref:foo)")

--- a/test/XReferee/Utils/Utf16Spec.hs
+++ b/test/XReferee/Utils/Utf16Spec.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module XReferee.Utils.Utf16Spec (spec) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text.Encoding qualified as TE
+import Skeletest
+import Skeletest.Prop.Gen qualified as Gen
+import Skeletest.Prop.Range qualified as Range
+import XReferee.Utils.Utf16 (utf16Length)
+
+spec :: Spec
+spec = do
+  describe "utf16Length" $ do
+    prop "matches reference implementation via encodeUtf16BE" $ do
+      t <- forAll $ Gen.text (Range.linear 0 100) Gen.unicodeAll
+      let bs = LBS.fromStrict (TE.encodeUtf8 t)
+      -- 1 UTF-16 code unit = 2 bytes, so we divide the length of the encoded
+      -- bytes by 2 to get the expected number of UTF-16 code units.
+      let expected = BS.length (TE.encodeUtf16BE t) `div` 2
+      utf16Length bs `shouldBe` expected

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -57,6 +57,7 @@ test-suite referee-tests
     XReferee.IntegrationSpec
     XReferee.SearchResultSpec
     XReferee.ReportSpec
+    XReferee.Utils.Utf16Spec
     XReferee.TestUtils.API
     XReferee.TestUtils.Git
     XReferee.TestUtils.Fixtures

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -62,6 +62,7 @@ test-suite referee-tests
   build-depends:
       base
     , aeson
+    , bytestring
     , containers
     , directory
     , filepath

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:
     XReferee.Report
     XReferee.SearchResult
+    XReferee.Utils.Utf16
   build-depends:
       base < 5
     , bytestring


### PR DESCRIPTION
When I added `ColumnRange` in #17, I failed to give unicode proper thought!

It seems that `ColumnRange` (as of the switch to bytestring parser) is now counting columns as bytes.

Since `ColumnRange` is meant to feed into the LSP server, and the LSP protocol [counts columns as UTF-16 code units by default](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocuments), I wrote this PR to fix how columns are counted.

I'm aware you recently made performance optimizations, so I ran the benchmarks before + after, and the results don't seem to have changed, but please do feel free to double-check them to be safe.