### PR TITLE
[#27] Fix `--include-untracked`

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -49,7 +49,7 @@ cliOptions =
         Opt.switch . mconcat $
           [ Opt.long "include-untracked"
           , Opt.short 'U'
-          , Opt.help "Include git untracked files in the search"
+          , Opt.help "Include git untracked non-ignored files in the search"
           ]
       pure SearchOpts{..}
 

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -182,7 +182,7 @@ findRefsInUntrackedNonIgnored opts = do
   -- However, all platforms have a limit on the maximum command line length.
   -- So we have to either split the list of files into batches, or run `git grep` once per file.
   -- We choose the latter for simplicity.
-  combineResults <$> forConcurrently files \file ->
+  concatSearchResults delims <$> forConcurrently files \file ->
     runGitGrep
       delims
       -- Interpret the filepath as a literal pathspec, so filenames containing
@@ -193,9 +193,6 @@ findRefsInUntrackedNonIgnored opts = do
       [file]
   where
     delims = opts.delims
-
-    combineResults :: [SearchResult] -> SearchResult
-    combineResults results = maybe (emptySearchResult delims) sconcat (NonEmpty.nonEmpty results)
 
 {- | List untracked, non-ignored files.
 Filepaths will be relative to the current working directory (not necessarily the repo root).
@@ -242,10 +239,7 @@ runGitGrep delims globalFlags flags pathspecs = do
   when (result.code /= ExitSuccess && (not . LBS.null) result.stderr) $
     -- TODO: Proper error - https://github.com/brandonchinn178/xreferee/issues/4
     errorWithoutStackTrace "git grep failed"
-  pure $
-    case NonEmpty.nonEmpty result.stdout of
-      Nothing -> emptySearchResult delims
-      Just results -> sconcat results
+  pure $ concatSearchResults delims result.stdout
   where
     args =
       concat
@@ -266,6 +260,9 @@ runGitGrep delims globalFlags flags pathspecs = do
       let filepath = LBS.Char8.unpack filepathStr
       lineNum <- readMaybe $ LBS.Char8.unpack lineNumStr
       Just (filepath, lineNum, match)
+
+concatSearchResults :: MarkerDelims -> [SearchResult] -> SearchResult
+concatSearchResults delims results = maybe (emptySearchResult delims) sconcat (NonEmpty.nonEmpty results)
 
 toSearchResult ::
   MarkerDelims ->

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
 module XReferee.SearchResult (
@@ -27,26 +26,27 @@ module XReferee.SearchResult (
   parseLabels,
 ) where
 
-import Control.DeepSeq (NFData (..), ($!!))
-import Control.Exception (evaluate)
+import Control.DeepSeq (NFData (..))
 import Control.Monad (guard, when)
 import Data.Bitraversable (bitraverse)
 import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
+import Data.Function ((&))
+import Data.Functor ((<&>))
 import Data.Int (Int64)
+import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import GHC.Records (HasField (..))
 import System.Exit (ExitCode (..))
 import System.IO qualified as IO
-import System.Process qualified as Process
 import Text.Read (readMaybe)
+import XReferee.Utils.Proc (StreamProcResult (..), chunkArgs, runProc, streamProcLines)
 import XReferee.Utils.Utf16 (utf16Length)
 
 data SearchOpts = SearchOpts
@@ -143,8 +143,94 @@ instance NFData ColumnRange where
 instance NFData LabelLoc where
   rnf loc = rnf loc.filepath `seq` rnf loc.lineNum `seq` rnf loc.columnRange
 
+{- | Find all refs and anchors in the current git repository.
+
+* If 'includeUntracked' is 'False', this will scan only files tracked by git (whether or not they are gitignored).
+* If it's 'True', untracked non-ignored files are also scanned.
+-}
 findRefsFromGit :: SearchOpts -> IO SearchResult
 findRefsFromGit opts = do
+  tracked <- findRefsInTracked opts
+  untracked <-
+    if opts.includeUntracked
+      then findRefsInUntrackedNonIgnored opts
+      else pure (emptySearchResult opts.delims)
+  pure (tracked <> untracked)
+
+findRefsInTracked :: SearchOpts -> IO SearchResult
+findRefsInTracked opts =
+  runGitGrep opts.delims trackedArgs
+  where
+    trackedArgs =
+      concat
+        [ gitGrepBaseArgs opts.delims
+        , ["--"]
+        , [":/"]
+        , [":!" <> i | i <- opts.ignores]
+        ]
+
+{- | Find refs and anchors in untracked, non-ignored files.
+
+We use `git ls-files` to enumerate the untracked, non-ignored files, and then run `git grep` on those files.
+See a detailed explanation here: https://github.com/brandonchinn178/xreferee/issues/27
+-}
+findRefsInUntrackedNonIgnored :: SearchOpts -> IO SearchResult
+findRefsInUntrackedNonIgnored opts = do
+  files <- listUntrackedFiles opts
+  -- NOTE: `git ls-files` can potentially return a long list of files, which we have to pass to `git grep`.
+  -- However, all platforms have a limit on the maximum command line length.
+  -- So we have to split the list of files into chunks that fit within that limit, and run `git grep` on each chunk.
+  case NonEmpty.nonEmpty (chunkArgs files) of
+    Nothing -> pure (emptySearchResult delims)
+    Just chunks -> sconcat <$> traverse (runGitGrep delims . untrackedArgs) chunks
+  where
+    delims = opts.delims
+
+    -- NOTE: `files` must be `NonEmpty`, otherwise `git grep` will revert to
+    -- its default behavior and also scan tracked files.
+    untrackedArgs :: NonEmpty Text -> [Text]
+    untrackedArgs files =
+      concat
+        [ gitGrepBaseArgs delims
+        , ["--untracked"] -- Without this, `git grep` ignores untracked pathspecs
+        , ["--"]
+        , NonEmpty.toList files
+        ]
+
+{- | List untracked, non-ignored files.
+Filepaths will be relative to the current working directory (not necessarily the repo root).
+-}
+listUntrackedFiles :: SearchOpts -> IO [Text]
+listUntrackedFiles opts = do
+  result <- runProc "git" args
+  LBS.hPutStr IO.stderr result.stderr
+  when (result.code /= ExitSuccess && (not . LBS.null) result.stderr) $
+    -- TODO: Proper error - https://github.com/brandonchinn178/xreferee/issues/4
+    errorWithoutStackTrace "git ls-files failed"
+  pure $
+    result.stdout
+      -- Split the lines by the NUL byte `\0`
+      & LBS.split 0
+      & filter (not . LBS.null)
+      <&> LBS.toStrict
+      <&> Text.decodeUtf8
+  where
+    args =
+      concat
+        [
+          [ "ls-files"
+          , "-z" -- Do not quote filenames with "unusual" characters. Output the filenames verbatim, separated by NUL bytes (i.e. `\0`).
+          , "--others" -- List only untracked files...
+          , "--exclude-standard" -- ... and apply the standard exclusion rules (e.g. .gitignore)
+          ]
+        , ["--"]
+        , [":/"]
+        , [":!" <> i | i <- opts.ignores]
+        ]
+
+-- | Run a single @git grep@ invocation and parse its output into a 'SearchResult'.
+runGitGrep :: MarkerDelims -> [Text] -> IO SearchResult
+runGitGrep delims args = do
   result <-
     streamProcLines "git" args $ \line -> do
       case extractGrepParts line of
@@ -162,26 +248,23 @@ findRefsFromGit opts = do
       Nothing -> emptySearchResult delims
       Just results -> sconcat results
   where
-    delims = opts.delims
-    args =
-      concat
-        [ ["grep"]
-        , ["-z", "--full-name", "--line-number"]
-        , ["-I"] -- ignore binary files
-        , ["--untracked" | opts.includeUntracked]
-        , ["--fixed-strings"]
-        , ["-e", delims.anchorStart]
-        , ["-e", delims.refStart]
-        , ["--"]
-        , [":/"]
-        , [":!" <> i | i <- opts.ignores]
-        ]
-
     extractGrepParts line = do
       [filepathStr, lineNumStr, match] <- pure $ LBS.split 0 line
       let filepath = LBS.Char8.unpack filepathStr
       lineNum <- readMaybe $ LBS.Char8.unpack lineNumStr
       Just (filepath, lineNum, match)
+
+-- | Shared @git grep@ flags and search patterns.
+gitGrepBaseArgs :: MarkerDelims -> [Text]
+gitGrepBaseArgs delims =
+  concat
+    [ ["grep"]
+    , ["-z", "--full-name", "--line-number"]
+    , ["-I"] -- ignore binary files
+    , ["--fixed-strings"]
+    , ["-e", delims.anchorStart]
+    , ["-e", delims.refStart]
+    ]
 
 toSearchResult ::
   MarkerDelims ->
@@ -295,37 +378,6 @@ instance HasField "splitOnce" ParseState (LazyByteString -> Maybe (LazyByteStrin
          in (res, state')
 
 {----- Utilities -----}
-
-data StreamProcResult a = StreamProcResult
-  { code :: ExitCode
-  , stdout :: a
-  , stderr :: LazyByteString
-  }
-
-streamProcLines ::
-  (NFData a) =>
-  FilePath ->
-  [Text] ->
-  (LazyByteString -> IO a) ->
-  IO (StreamProcResult [a])
-streamProcLines cmd args onStdoutLine = do
-  let proc =
-        (Process.proc cmd (map Text.unpack args))
-          { Process.std_out = Process.CreatePipe
-          , Process.std_err = Process.CreatePipe
-          }
-  Process.withCreateProcess proc $ \_ stdoutHandle stderrHandle ph -> do
-    rawStdout <- maybe (pure "") LBS.hGetContents stdoutHandle
-    stdout <- (evaluate $!!) =<< mapM onStdoutLine (LBS.Char8.lines rawStdout)
-    rawStderr <- maybe (pure "") LBS.hGetContents stderrHandle
-    stderr <- evaluate $!! rawStderr
-    code <- Process.waitForProcess ph
-    pure
-      StreamProcResult
-        { code
-        , stdout
-        , stderr
-        }
 
 partitionUnfoldr :: (s -> Maybe (Either a b, s)) -> s -> ([a], [b])
 partitionUnfoldr f =

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -34,13 +34,13 @@ import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
 import Data.Function ((&))
-import Data.Functor ((<&>))
 import Data.Int (Int64)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import GHC.Records (HasField (..))
 import System.Exit (ExitCode (..))
@@ -212,11 +212,10 @@ listUntrackedFiles opts = do
     errorWithoutStackTrace "git ls-files failed"
   pure $
     result.stdout
-      -- Split the lines by the NUL byte `\0`
-      & LBS.split 0
-      & filter (not . LBS.null)
-      <&> LBS.toStrict
-      <&> Text.decodeUtf8
+      & LBS.toStrict
+      & Text.decodeUtf8
+      & Text.splitOn "\0"
+      & filter (not . Text.null)
   where
     args =
       concat

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -177,24 +177,31 @@ See a detailed explanation here: https://github.com/brandonchinn178/xreferee/iss
 findRefsInUntrackedNonIgnored :: SearchOpts -> IO SearchResult
 findRefsInUntrackedNonIgnored opts = do
   files <- listUntrackedFiles opts
+  -- Turn each path into a literal pathspec, so filenames containing
+  -- glob metacharacters (e.g. `[id].tsx`) are interpreted literally and not as a glob pattern.
+  let pathspecs = files <&> (literalPathspecPrefix <>)
   -- NOTE: `git ls-files` can potentially return a long list of files, which we have to pass to `git grep`.
   -- However, all platforms have a limit on the maximum command line length.
-  -- So we have to split the list of files into chunks that fit within that limit, and run `git grep` on each chunk.
-  case NonEmpty.nonEmpty (chunkArgs files) of
+  -- So we have to split the list of pathspecs into chunks that fit within that limit, and run `git grep` on each chunk.
+  case NonEmpty.nonEmpty (chunkArgs pathspecs) of
     Nothing -> pure (emptySearchResult delims)
     Just chunks -> sconcat <$> traverse (runGitGrep delims . untrackedArgs) chunks
   where
     delims = opts.delims
 
-    -- NOTE: `files` must be `NonEmpty`, otherwise `git grep` will revert to
+    -- A prefix that tells git to interpret a pathspec literally, and not as a glob pattern.
+    literalPathspecPrefix :: Text
+    literalPathspecPrefix = ":(literal)"
+
+    -- NOTE: `pathspecs` must be `NonEmpty`, otherwise `git grep` will revert to
     -- its default behavior and also scan tracked files.
     untrackedArgs :: NonEmpty Text -> [Text]
-    untrackedArgs files =
+    untrackedArgs pathspecs =
       concat
         [ gitGrepBaseArgs delims
-        , ["--untracked"] -- Without this, `git grep` ignores untracked pathspecs
+        , ["--untracked"] -- Without this, `git grep` ignores untracked files
         , ["--"]
-        , NonEmpty.toList files
+        , NonEmpty.toList pathspecs
         ]
 
 {- | List untracked, non-ignored files.

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -179,15 +179,15 @@ findRefsInUntrackedNonIgnored opts = do
   results <- forConcurrently files \file ->
     runGitGrep
       delims
-      -- Interpret the filepath as a literal pathspec, so filenames containing
-      -- glob metacharacters (e.g. `[id].tsx`) are matched literally and not as a glob pattern.
-      ["--literal-pathspecs"]
-      -- Without this, `git grep` ignores untracked files
+      globalFlags
       ["--untracked"]
       [file]
   pure $ concatSearchResults delims results
   where
     delims = opts.delims
+    -- Interpret the filepath as a literal pathspec, so filenames containing
+    -- glob metacharacters (e.g. `[id].tsx`) are matched literally and not as a glob pattern.
+    globalFlags = ["--literal-pathspecs"]
 
 {- | List untracked, non-ignored files.
 Filepaths will be relative to the current working directory (not necessarily the repo root).

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -178,29 +178,25 @@ See a detailed explanation here: https://github.com/brandonchinn178/xreferee/iss
 findRefsInUntrackedNonIgnored :: SearchOpts -> IO SearchResult
 findRefsInUntrackedNonIgnored opts = do
   files <- listUntrackedFiles opts
-  -- Turn each path into a literal pathspec, so filenames containing
-  -- glob metacharacters (e.g. `[id].tsx`) are interpreted literally and not as a glob pattern.
-  let pathspecs = files <&> (literalPathspecPrefix <>)
   -- NOTE: `git ls-files` can potentially return a long list of files, which we have to pass to `git grep`.
   -- However, all platforms have a limit on the maximum command line length.
   -- So we have to split the list of pathspecs into chunks that fit within that limit, and run `git grep` on each chunk.
-  combineResults <$> mapConcurrently (runGitGrep delims . untrackedArgs) (chunkArgs pathspecs)
+  combineResults <$> mapConcurrently (runGitGrep delims . untrackedArgs) (chunkArgs files)
   where
     delims = opts.delims
 
     combineResults :: [SearchResult] -> SearchResult
     combineResults results = maybe (emptySearchResult delims) sconcat (NonEmpty.nonEmpty results)
 
-    -- A prefix that tells git to interpret a pathspec literally, and not as a glob pattern.
-    literalPathspecPrefix :: Text
-    literalPathspecPrefix = ":(literal)"
-
     -- NOTE: `pathspecs` must be `NonEmpty`, otherwise `git grep` will revert to
     -- its default behavior and also scan tracked files.
     untrackedArgs :: NonEmpty Text -> [Text]
     untrackedArgs pathspecs =
       concat
-        [ gitGrepBaseArgs delims
+        [ -- Interpret filepaths as literal pathspecs, so filenames containing
+          -- glob metacharacters (e.g. `[id].tsx`) are matched literally and not as a glob pattern.
+          ["--literal-pathspecs"]
+        , gitGrepBaseArgs delims
         , ["--untracked"] -- Without this, `git grep` ignores untracked files
         , ["--"]
         , NonEmpty.toList pathspecs

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -47,7 +47,7 @@ import GHC.Records (HasField (..))
 import System.Exit (ExitCode (..))
 import System.IO qualified as IO
 import Text.Read (readMaybe)
-import XReferee.Utils.Proc (StreamProcResult (..), runProc, streamProcLines)
+import XReferee.Utils.Proc (StreamProcResult (..), withRunProc)
 import XReferee.Utils.Utf16 (utf16Length)
 
 data SearchOpts = SearchOpts
@@ -160,15 +160,9 @@ findRefsFromGit opts = do
 
 findRefsInTracked :: SearchOpts -> IO SearchResult
 findRefsInTracked opts =
-  runGitGrep
-    opts.delims
-    []
-    []
-    ( concat
-        [ [":/"]
-        , [":!" <> i | i <- opts.ignores]
-        ]
-    )
+  runGitGrep opts.delims [] [] pathspecs
+  where
+    pathspecs = ":/" : [":!" <> i | i <- opts.ignores]
 
 {- | Find refs and anchors in untracked, non-ignored files.
 
@@ -182,7 +176,7 @@ findRefsInUntrackedNonIgnored opts = do
   -- However, all platforms have a limit on the maximum command line length.
   -- So we have to either split the list of files into batches, or run `git grep` once per file.
   -- We choose the latter for simplicity.
-  concatSearchResults delims <$> forConcurrently files \file ->
+  results <- forConcurrently files \file ->
     runGitGrep
       delims
       -- Interpret the filepath as a literal pathspec, so filenames containing
@@ -191,6 +185,7 @@ findRefsInUntrackedNonIgnored opts = do
       -- Without this, `git grep` ignores untracked files
       ["--untracked"]
       [file]
+  pure $ concatSearchResults delims results
   where
     delims = opts.delims
 
@@ -199,60 +194,40 @@ Filepaths will be relative to the current working directory (not necessarily the
 -}
 listUntrackedFiles :: SearchOpts -> IO [Text]
 listUntrackedFiles opts = do
-  result <- runProc "git" args
-  LBS.hPutStr IO.stderr result.stderr
-  when (result.code /= ExitSuccess && (not . LBS.null) result.stderr) $
-    -- TODO: Proper error - https://github.com/brandonchinn178/xreferee/issues/4
-    errorWithoutStackTrace "git ls-files failed"
+  stdout <- runGit [] "ls-files" flags pathspecs
   pure $
-    result.stdout
+    stdout
       & LBS.toStrict
       & Text.decodeUtf8
       & Text.splitOn "\0"
       & filter (not . Text.null)
   where
-    args =
-      concat
-        [
-          [ "ls-files"
-          , "-z" -- Do not quote filenames with "unusual" characters. Output the filenames verbatim, separated by NUL bytes (i.e. `\0`).
-          , "--others" -- List only untracked files...
-          , "--exclude-standard" -- ... and apply the standard exclusion rules (e.g. .gitignore)
-          ]
-        , ["--"]
-        , [":/"]
-        , [":!" <> i | i <- opts.ignores]
-        ]
+    flags =
+      [ "-z" -- Do not quote filenames with "unusual" characters. Output the filenames verbatim, separated by NUL bytes (i.e. `\0`).
+      , "--others" -- List only untracked files...
+      , "--exclude-standard" -- ... and apply the standard exclusion rules (e.g. .gitignore)
+      ]
+    pathspecs = ":/" : [":!" <> i | i <- opts.ignores]
 
 -- | Run a single @git grep@ invocation and parse its output into a 'SearchResult'.
 runGitGrep :: MarkerDelims -> [Text] -> [Text] -> [Text] -> IO SearchResult
 runGitGrep delims globalFlags flags pathspecs = do
-  result <-
-    streamProcLines "git" args $ \line -> do
-      case extractGrepParts line of
-        Nothing -> do
-          LBS.Char8.hPutStrLn IO.stderr $ "[WARN] Found line in unexpected format: " <> line
-          pure $ emptySearchResult delims
-        Just (filepath, lineNum, match) -> do
-          pure $ toSearchResult delims filepath lineNum match
-  LBS.hPutStr IO.stderr result.stderr
-  when (result.code /= ExitSuccess && (not . LBS.null) result.stderr) $
-    -- TODO: Proper error - https://github.com/brandonchinn178/xreferee/issues/4
-    errorWithoutStackTrace "git grep failed"
-  pure $ concatSearchResults delims result.stdout
+  results <- streamGitLines globalFlags "grep" (grepArgs <> flags) pathspecs \line ->
+    case extractGrepParts line of
+      Nothing -> do
+        LBS.Char8.hPutStrLn IO.stderr $ "[WARN] Found line in unexpected format: " <> line
+        pure $ emptySearchResult delims
+      Just (filepath, lineNum, match) ->
+        pure $ toSearchResult delims filepath lineNum match
+  pure $ concatSearchResults delims results
   where
-    args =
+    grepArgs =
       concat
-        [ globalFlags
-        , ["grep"]
-        , ["-z", "--full-name", "--line-number"]
+        [ ["-z", "--full-name", "--line-number"]
         , ["-I"] -- ignore binary files
         , ["--fixed-strings"]
         , ["-e", delims.anchorStart]
         , ["-e", delims.refStart]
-        , flags
-        , ["--"]
-        , pathspecs
         ]
 
     extractGrepParts line = do
@@ -376,6 +351,44 @@ instance HasField "splitOnce" ParseState (LazyByteString -> Maybe (LazyByteStrin
          in (res, state')
 
 {----- Utilities -----}
+
+{- | Run a @git@ subcommand, checking its exit code and forwarding stderr,
+then passing its raw stdout through @onStdout@ to produce the result.
+-}
+withRunGit ::
+  (NFData a) =>
+  [Text] ->
+  Text ->
+  [Text] ->
+  [Text] ->
+  (LazyByteString -> IO a) ->
+  IO a
+withRunGit globalFlags subcommand flags pathspecs onStdout = do
+  result <- withRunProc "git" args onStdout
+  LBS.hPutStr IO.stderr result.stderr
+  when (result.code /= ExitSuccess && (not . LBS.null) result.stderr) $
+    -- TODO: Proper error - https://github.com/brandonchinn178/xreferee/issues/4
+    errorWithoutStackTrace $
+      "git " <> Text.unpack subcommand <> " failed"
+  pure result.stdout
+  where
+    args = concat [globalFlags, [subcommand], flags, ["--"], pathspecs]
+
+-- | Run a @git@ subcommand and capture its stdout, fully forced.
+runGit :: [Text] -> Text -> [Text] -> [Text] -> IO LazyByteString
+runGit globalFlags subcommand flags pathspecs = withRunGit globalFlags subcommand flags pathspecs pure
+
+-- | Run a @git@ subcommand, applying @onLine@ to each line of stdout.
+streamGitLines ::
+  (NFData a) =>
+  [Text] ->
+  Text ->
+  [Text] ->
+  [Text] ->
+  (LazyByteString -> IO a) ->
+  IO [a]
+streamGitLines globalFlags subcommand flags pathspecs onLine =
+  withRunGit globalFlags subcommand flags pathspecs (mapM onLine . LBS.Char8.lines)
 
 partitionUnfoldr :: (s -> Maybe (Either a b, s)) -> s -> ([a], [b])
 partitionUnfoldr f =

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -26,6 +26,7 @@ module XReferee.SearchResult (
   parseLabels,
 ) where
 
+import Control.Concurrent.Async (mapConcurrently)
 import Control.DeepSeq (NFData (..))
 import Control.Monad (guard, when)
 import Data.Bitraversable (bitraverse)
@@ -183,11 +184,12 @@ findRefsInUntrackedNonIgnored opts = do
   -- NOTE: `git ls-files` can potentially return a long list of files, which we have to pass to `git grep`.
   -- However, all platforms have a limit on the maximum command line length.
   -- So we have to split the list of pathspecs into chunks that fit within that limit, and run `git grep` on each chunk.
-  case NonEmpty.nonEmpty (chunkArgs pathspecs) of
-    Nothing -> pure (emptySearchResult delims)
-    Just chunks -> sconcat <$> traverse (runGitGrep delims . untrackedArgs) chunks
+  combineResults <$> mapConcurrently (runGitGrep delims . untrackedArgs) (chunkArgs pathspecs)
   where
     delims = opts.delims
+
+    combineResults :: [SearchResult] -> SearchResult
+    combineResults results = maybe (emptySearchResult delims) sconcat (NonEmpty.nonEmpty results)
 
     -- A prefix that tells git to interpret a pathspec literally, and not as a glob pattern.
     literalPathspecPrefix :: Text

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -36,7 +36,6 @@ import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.Int (Int64)
-import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -47,7 +46,7 @@ import GHC.Records (HasField (..))
 import System.Exit (ExitCode (..))
 import System.IO qualified as IO
 import Text.Read (readMaybe)
-import XReferee.Utils.Proc (StreamProcResult (..), chunkArgs, runProc, streamProcLines)
+import XReferee.Utils.Proc (StreamProcResult (..), runProc, streamProcLines)
 import XReferee.Utils.Utf16 (utf16Length)
 
 data SearchOpts = SearchOpts
@@ -180,26 +179,25 @@ findRefsInUntrackedNonIgnored opts = do
   files <- listUntrackedFiles opts
   -- NOTE: `git ls-files` can potentially return a long list of files, which we have to pass to `git grep`.
   -- However, all platforms have a limit on the maximum command line length.
-  -- So we have to split the list of pathspecs into chunks that fit within that limit, and run `git grep` on each chunk.
-  combineResults <$> mapConcurrently (runGitGrep delims . untrackedArgs) (chunkArgs files)
+  -- So we have to either split the list of files into batches, or run `git grep` once per file.
+  -- We choose the latter for simplicity.
+  combineResults <$> mapConcurrently (runGitGrep delims . untrackedArgs) files
   where
     delims = opts.delims
 
     combineResults :: [SearchResult] -> SearchResult
     combineResults results = maybe (emptySearchResult delims) sconcat (NonEmpty.nonEmpty results)
 
-    -- NOTE: `pathspecs` must be `NonEmpty`, otherwise `git grep` will revert to
-    -- its default behavior and also scan tracked files.
-    untrackedArgs :: NonEmpty Text -> [Text]
-    untrackedArgs pathspecs =
+    untrackedArgs :: Text -> [Text]
+    untrackedArgs file =
       concat
-        [ -- Interpret filepaths as literal pathspecs, so filenames containing
+        [ -- Interpret the filepath as a literal pathspec, so filenames containing
           -- glob metacharacters (e.g. `[id].tsx`) are matched literally and not as a glob pattern.
           ["--literal-pathspecs"]
         , gitGrepBaseArgs delims
         , ["--untracked"] -- Without this, `git grep` ignores untracked files
         , ["--"]
-        , NonEmpty.toList pathspecs
+        , [file]
         ]
 
 {- | List untracked, non-ignored files.

--- a/src/XReferee/SearchResult.hs
+++ b/src/XReferee/SearchResult.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
@@ -26,7 +27,7 @@ module XReferee.SearchResult (
   parseLabels,
 ) where
 
-import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.Async (forConcurrently)
 import Control.DeepSeq (NFData (..))
 import Control.Monad (guard, when)
 import Data.Bitraversable (bitraverse)
@@ -159,15 +160,15 @@ findRefsFromGit opts = do
 
 findRefsInTracked :: SearchOpts -> IO SearchResult
 findRefsInTracked opts =
-  runGitGrep opts.delims trackedArgs
-  where
-    trackedArgs =
-      concat
-        [ gitGrepBaseArgs opts.delims
-        , ["--"]
-        , [":/"]
+  runGitGrep
+    opts.delims
+    []
+    []
+    ( concat
+        [ [":/"]
         , [":!" <> i | i <- opts.ignores]
         ]
+    )
 
 {- | Find refs and anchors in untracked, non-ignored files.
 
@@ -181,24 +182,20 @@ findRefsInUntrackedNonIgnored opts = do
   -- However, all platforms have a limit on the maximum command line length.
   -- So we have to either split the list of files into batches, or run `git grep` once per file.
   -- We choose the latter for simplicity.
-  combineResults <$> mapConcurrently (runGitGrep delims . untrackedArgs) files
+  combineResults <$> forConcurrently files \file ->
+    runGitGrep
+      delims
+      -- Interpret the filepath as a literal pathspec, so filenames containing
+      -- glob metacharacters (e.g. `[id].tsx`) are matched literally and not as a glob pattern.
+      ["--literal-pathspecs"]
+      -- Without this, `git grep` ignores untracked files
+      ["--untracked"]
+      [file]
   where
     delims = opts.delims
 
     combineResults :: [SearchResult] -> SearchResult
     combineResults results = maybe (emptySearchResult delims) sconcat (NonEmpty.nonEmpty results)
-
-    untrackedArgs :: Text -> [Text]
-    untrackedArgs file =
-      concat
-        [ -- Interpret the filepath as a literal pathspec, so filenames containing
-          -- glob metacharacters (e.g. `[id].tsx`) are matched literally and not as a glob pattern.
-          ["--literal-pathspecs"]
-        , gitGrepBaseArgs delims
-        , ["--untracked"] -- Without this, `git grep` ignores untracked files
-        , ["--"]
-        , [file]
-        ]
 
 {- | List untracked, non-ignored files.
 Filepaths will be relative to the current working directory (not necessarily the repo root).
@@ -231,8 +228,8 @@ listUntrackedFiles opts = do
         ]
 
 -- | Run a single @git grep@ invocation and parse its output into a 'SearchResult'.
-runGitGrep :: MarkerDelims -> [Text] -> IO SearchResult
-runGitGrep delims args = do
+runGitGrep :: MarkerDelims -> [Text] -> [Text] -> [Text] -> IO SearchResult
+runGitGrep delims globalFlags flags pathspecs = do
   result <-
     streamProcLines "git" args $ \line -> do
       case extractGrepParts line of
@@ -250,23 +247,25 @@ runGitGrep delims args = do
       Nothing -> emptySearchResult delims
       Just results -> sconcat results
   where
+    args =
+      concat
+        [ globalFlags
+        , ["grep"]
+        , ["-z", "--full-name", "--line-number"]
+        , ["-I"] -- ignore binary files
+        , ["--fixed-strings"]
+        , ["-e", delims.anchorStart]
+        , ["-e", delims.refStart]
+        , flags
+        , ["--"]
+        , pathspecs
+        ]
+
     extractGrepParts line = do
       [filepathStr, lineNumStr, match] <- pure $ LBS.split 0 line
       let filepath = LBS.Char8.unpack filepathStr
       lineNum <- readMaybe $ LBS.Char8.unpack lineNumStr
       Just (filepath, lineNum, match)
-
--- | Shared @git grep@ flags and search patterns.
-gitGrepBaseArgs :: MarkerDelims -> [Text]
-gitGrepBaseArgs delims =
-  concat
-    [ ["grep"]
-    , ["-z", "--full-name", "--line-number"]
-    , ["-I"] -- ignore binary files
-    , ["--fixed-strings"]
-    , ["-e", delims.anchorStart]
-    , ["-e", delims.refStart]
-    ]
 
 toSearchResult ::
   MarkerDelims ->

--- a/src/XReferee/Utils/Proc.hs
+++ b/src/XReferee/Utils/Proc.hs
@@ -7,20 +7,15 @@ module XReferee.Utils.Proc (
   StreamProcResult (..),
   streamProcLines,
   runProc,
-  chunkArgs,
 ) where
 
 import Control.DeepSeq (NFData, ($!!))
 import Control.Exception (evaluate)
-import Data.ByteString qualified as BS
 import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
-import Data.List.NonEmpty (NonEmpty (..))
-import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Text.Encoding qualified as Text
 import System.Exit (ExitCode)
 import System.Process qualified as Process
 
@@ -70,37 +65,3 @@ runProcWith cmd args onStdout = do
         , stdout
         , stderr
         }
-
-{- | Different platforms have limits on the maximum command line length.
-This function splits a list of arguments into chunks that fit within that limit, so that
-each chunk can be passed to a command line invocation without exceeding the limit on any platform.
--}
-chunkArgs :: [Text] -> [NonEmpty Text]
-chunkArgs = go
-  where
-    go :: [Text] -> [NonEmpty Text]
-    go [] = []
-    go (x : xs) =
-      -- Start a chunk with the first argument, and fill it with as many arguments as possible.
-      let (chunk, rest) = fillChunk (argLen x) (NonEmpty.singleton x) xs
-       in chunk : go rest
-
-    fillChunk :: Int -> NonEmpty Text -> [Text] -> (NonEmpty Text, [Text])
-    fillChunk _ chunk [] = (NonEmpty.reverse chunk, [])
-    fillChunk chunkSize chunk (y : ys)
-      | chunkSize + argLen y > maxChunkBytes =
-          -- The argument `y` doesn't fit in the current chunk, so we return.
-          (NonEmpty.reverse chunk, y : ys)
-      | otherwise =
-          fillChunk (chunkSize + argLen y) (NonEmpty.cons y chunk) ys
-
-    argLen :: Text -> Int
-    argLen t = BS.length (Text.encodeUtf8 t) + 1 -- +1 for the arg separator
-
-    {-
-      Windows's `CreateProcessW` has a maximum command line length of 32,767 characters.
-      https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
-      The limit on Linux and macOS is much higher.
-      So we use a conservative limit to ensure compatibility across platforms.
-    -}
-    maxChunkBytes = 28000

--- a/src/XReferee/Utils/Proc.hs
+++ b/src/XReferee/Utils/Proc.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module XReferee.Utils.Proc (
+  StreamProcResult (..),
+  streamProcLines,
+  runProc,
+  chunkArgs,
+) where
+
+import Control.DeepSeq (NFData, ($!!))
+import Control.Exception (evaluate)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy (LazyByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import System.Exit (ExitCode)
+import System.Process qualified as Process
+
+data StreamProcResult a = StreamProcResult
+  { code :: ExitCode
+  , stdout :: a
+  , stderr :: LazyByteString
+  }
+
+streamProcLines ::
+  (NFData a) =>
+  FilePath ->
+  [Text] ->
+  (LazyByteString -> IO a) ->
+  IO (StreamProcResult [a])
+streamProcLines cmd args onStdoutLine = do
+  let proc =
+        (Process.proc cmd (map Text.unpack args))
+          { Process.std_out = Process.CreatePipe
+          , Process.std_err = Process.CreatePipe
+          }
+  Process.withCreateProcess proc $ \_ stdoutHandle stderrHandle ph -> do
+    rawStdout <- maybe (pure "") LBS.hGetContents stdoutHandle
+    stdout <- (evaluate $!!) =<< mapM onStdoutLine (LBS.Char8.lines rawStdout)
+    rawStderr <- maybe (pure "") LBS.hGetContents stderrHandle
+    stderr <- evaluate $!! rawStderr
+    code <- Process.waitForProcess ph
+    pure
+      StreamProcResult
+        { code
+        , stdout
+        , stderr
+        }
+
+{- | Run a process and capture its stdout and stderr, fully forced.
+Unlike 'streamProcLines' this realizes the entire stdout in memory
+-}
+runProc :: FilePath -> [Text] -> IO (StreamProcResult LazyByteString)
+runProc cmd args = do
+  let proc =
+        (Process.proc cmd (map Text.unpack args))
+          { Process.std_out = Process.CreatePipe
+          , Process.std_err = Process.CreatePipe
+          }
+  Process.withCreateProcess proc $ \_ stdoutHandle stderrHandle ph -> do
+    rawStdout <- maybe (pure "") LBS.hGetContents stdoutHandle
+    stdout <- evaluate $!! rawStdout
+    rawStderr <- maybe (pure "") LBS.hGetContents stderrHandle
+    stderr <- evaluate $!! rawStderr
+    code <- Process.waitForProcess ph
+    pure
+      StreamProcResult
+        { code
+        , stdout
+        , stderr
+        }
+
+{- | Different platforms have limits on the maximum command line length.
+This function splits a list of arguments into chunks that fit within that limit, so that
+each chunk can be passed to a command line invocation without exceeding the limit on any platform.
+-}
+chunkArgs :: [Text] -> [NonEmpty Text]
+chunkArgs = go
+  where
+    go :: [Text] -> [NonEmpty Text]
+    go [] = []
+    go (x : xs) =
+      -- Start a chunk with the first argument, and fill it with as many arguments as possible.
+      let (chunk, rest) = fillChunk (argLen x) (NonEmpty.singleton x) xs
+       in chunk : go rest
+
+    fillChunk :: Int -> NonEmpty Text -> [Text] -> (NonEmpty Text, [Text])
+    fillChunk _ chunk [] = (NonEmpty.reverse chunk, [])
+    fillChunk chunkSize chunk (y : ys)
+      | chunkSize + argLen y > maxChunkBytes =
+          -- The argument `y` doesn't fit in the current chunk, so we return.
+          (NonEmpty.reverse chunk, y : ys)
+      | otherwise =
+          fillChunk (chunkSize + argLen y) (NonEmpty.cons y chunk) ys
+
+    argLen :: Text -> Int
+    argLen t = BS.length (Text.encodeUtf8 t) + 1 -- +1 for the arg separator
+
+    {-
+      Windows's `CreateProcessW` has a maximum command line length of 32,767 characters.
+      https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
+      The limit on Linux and macOS is much higher.
+      So we use a conservative limit to ensure compatibility across platforms.
+    -}
+    maxChunkBytes = 28000

--- a/src/XReferee/Utils/Proc.hs
+++ b/src/XReferee/Utils/Proc.hs
@@ -36,30 +36,23 @@ streamProcLines ::
   [Text] ->
   (LazyByteString -> IO a) ->
   IO (StreamProcResult [a])
-streamProcLines cmd args onStdoutLine = do
-  let proc =
-        (Process.proc cmd (map Text.unpack args))
-          { Process.std_out = Process.CreatePipe
-          , Process.std_err = Process.CreatePipe
-          }
-  Process.withCreateProcess proc $ \_ stdoutHandle stderrHandle ph -> do
-    rawStdout <- maybe (pure "") LBS.hGetContents stdoutHandle
-    stdout <- (evaluate $!!) =<< mapM onStdoutLine (LBS.Char8.lines rawStdout)
-    rawStderr <- maybe (pure "") LBS.hGetContents stderrHandle
-    stderr <- evaluate $!! rawStderr
-    code <- Process.waitForProcess ph
-    pure
-      StreamProcResult
-        { code
-        , stdout
-        , stderr
-        }
+streamProcLines cmd args onStdoutLine =
+  runProcWith cmd args (mapM onStdoutLine . LBS.Char8.lines)
 
 {- | Run a process and capture its stdout and stderr, fully forced.
 Unlike 'streamProcLines' this realizes the entire stdout in memory
 -}
 runProc :: FilePath -> [Text] -> IO (StreamProcResult LazyByteString)
-runProc cmd args = do
+runProc cmd args = runProcWith cmd args pure
+
+-- | Run a process, passing its raw stdout through the given callback to produce the result.
+runProcWith ::
+  (NFData a) =>
+  FilePath ->
+  [Text] ->
+  (LazyByteString -> IO a) ->
+  IO (StreamProcResult a)
+runProcWith cmd args onStdout = do
   let proc =
         (Process.proc cmd (map Text.unpack args))
           { Process.std_out = Process.CreatePipe
@@ -67,7 +60,7 @@ runProc cmd args = do
           }
   Process.withCreateProcess proc $ \_ stdoutHandle stderrHandle ph -> do
     rawStdout <- maybe (pure "") LBS.hGetContents stdoutHandle
-    stdout <- evaluate $!! rawStdout
+    stdout <- (evaluate $!!) =<< onStdout rawStdout
     rawStderr <- maybe (pure "") LBS.hGetContents stderrHandle
     stderr <- evaluate $!! rawStderr
     code <- Process.waitForProcess ph

--- a/src/XReferee/Utils/Proc.hs
+++ b/src/XReferee/Utils/Proc.hs
@@ -5,15 +5,13 @@
 
 module XReferee.Utils.Proc (
   StreamProcResult (..),
-  streamProcLines,
-  runProc,
+  withRunProc,
 ) where
 
 import Control.DeepSeq (NFData, ($!!))
 import Control.Exception (evaluate)
 import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Lazy qualified as LBS
-import Data.ByteString.Lazy.Char8 qualified as LBS.Char8
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.Exit (ExitCode)
@@ -25,29 +23,14 @@ data StreamProcResult a = StreamProcResult
   , stderr :: LazyByteString
   }
 
-streamProcLines ::
-  (NFData a) =>
-  FilePath ->
-  [Text] ->
-  (LazyByteString -> IO a) ->
-  IO (StreamProcResult [a])
-streamProcLines cmd args onStdoutLine =
-  runProcWith cmd args (mapM onStdoutLine . LBS.Char8.lines)
-
-{- | Run a process and capture its stdout and stderr, fully forced.
-Unlike 'streamProcLines' this realizes the entire stdout in memory
--}
-runProc :: FilePath -> [Text] -> IO (StreamProcResult LazyByteString)
-runProc cmd args = runProcWith cmd args pure
-
 -- | Run a process, passing its raw stdout through the given callback to produce the result.
-runProcWith ::
+withRunProc ::
   (NFData a) =>
   FilePath ->
   [Text] ->
   (LazyByteString -> IO a) ->
   IO (StreamProcResult a)
-runProcWith cmd args onStdout = do
+withRunProc cmd args onStdout = do
   let proc =
         (Process.proc cmd (map Text.unpack args))
           { Process.std_out = Process.CreatePipe

--- a/test/XReferee/SearchResultSpec.hs
+++ b/test/XReferee/SearchResultSpec.hs
@@ -17,7 +17,11 @@ import XReferee.SearchResult (
   findRefsFromGit,
  )
 import XReferee.TestUtils.API (anchor, defaultOpts, loc', ref)
-import XReferee.TestUtils.Git (withGitRepo)
+import XReferee.TestUtils.Git (
+  GitFileState (..),
+  withGitRepo,
+  withGitRepoAndFileStates,
+ )
 
 spec :: Spec
 spec = do
@@ -126,6 +130,94 @@ spec = do
                 }
         findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
 
+    it "searches tracked files (ignored or not), but not untracked files, by default" $ do
+      let files =
+            [ (Tracked, "a-tracked.md", "@(ref:a-tracked)")
+            , (TrackedIgnored, "b-tracked-ignored.md", "@(ref:b-tracked-ignored)")
+            , (Untracked, "c-untracked.md", "@(ref:c-untracked)")
+            , (UntrackedIgnored, "d-untracked-ignored.md", "@(ref:d-untracked-ignored)")
+            ]
+      withGitRepoAndFileStates files $ do
+        let expected =
+              SearchResult
+                { delims = defaultOpts.delims
+                , anchors = mempty
+                , references =
+                    Map.fromList
+                      [ ref "a-tracked" [loc' "a-tracked.md" 1 (1, 16)]
+                      , ref "b-tracked-ignored" [loc' "b-tracked-ignored.md" 1 (1, 24)]
+                      ]
+                }
+        findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
+
+    it "also searches untracked, non-ignored files with includeUntracked" $ do
+      let files =
+            [ (Tracked, "a-tracked.md", "@(ref:a-tracked)")
+            , (TrackedIgnored, "b-tracked-ignored.md", "@(ref:b-tracked-ignored)")
+            , (Untracked, "c-untracked.md", "@(ref:c-untracked)")
+            , (UntrackedIgnored, "d-untracked-ignored.md", "@(ref:d-untracked-ignored)")
+            ]
+      withGitRepoAndFileStates files $ do
+        let expected =
+              SearchResult
+                { delims = defaultOpts.delims
+                , anchors = mempty
+                , references =
+                    Map.fromList
+                      [ ref "a-tracked" [loc' "a-tracked.md" 1 (1, 16)]
+                      , ref "b-tracked-ignored" [loc' "b-tracked-ignored.md" 1 (1, 24)]
+                      , ref "c-untracked" [loc' "c-untracked.md" 1 (1, 18)]
+                      ]
+                }
+        findRefsFromGit defaultOpts{includeUntracked = True}
+          `shouldSatisfy` P.returns (P.eq expected)
+
+    it "applies `ignores` to both tracked and untracked files when includeUntracked is set" $ do
+      let files =
+            [ (Tracked, "keep/a.md", "@(ref:keep-tracked)")
+            , (Tracked, "excluded/b.md", "@(ref:excluded-tracked)")
+            , (Untracked, "keep/c.md", "@(ref:keep-untracked)")
+            , (Untracked, "excluded/d.md", "@(ref:excluded-untracked)")
+            ]
+      withGitRepoAndFileStates files $ do
+        let opts = defaultOpts{ignores = ["excluded/"], includeUntracked = True}
+            expected =
+              SearchResult
+                { delims = opts.delims
+                , anchors = mempty
+                , references =
+                    Map.fromList
+                      [ ref "keep-tracked" [loc' "keep/a.md" 1 (1, 19)]
+                      , ref "keep-untracked" [loc' "keep/c.md" 1 (1, 21)]
+                      ]
+                }
+        findRefsFromGit opts `shouldSatisfy` P.returns (P.eq expected)
+
+    it "treats untracked filenames as literal pathspecs, not globs" $ do
+      -- `[id].tsx` is a perfectly valid untracked filename (e.g. a Next.js dynamic route).
+      -- If it were to be passed to `git grep --untracked` as a glob, it would also match
+      -- the tracked file `i.tsx`.
+      -- As a result, both the `git grep` and the `git grep --untracked` passes would scan `i.tsx`,
+      -- and the references in the file would be counted twice.
+      -- This test ensures the string `[id].tsx` is treated as a literal, not as a glob.
+      let files =
+            [ (Tracked, "i.tsx", "@(ref:tracked-i)")
+            , (Untracked, "[id].tsx", "@(ref:untracked-dynamic)")
+            ]
+      withGitRepoAndFileStates files $ do
+        let expected =
+              SearchResult
+                { delims = defaultOpts.delims
+                , anchors = mempty
+                , references =
+                    Map.fromList
+                      [ ref "tracked-i" [loc' "i.tsx" 1 (1, 16)]
+                      , ref "untracked-dynamic" [loc' "[id].tsx" 1 (1, 24)]
+                      ]
+                }
+        findRefsFromGit defaultOpts{includeUntracked = True}
+          `shouldSatisfy` P.returns (P.eq expected)
+
     it "finds references from subdirectory" $ do
       let files =
             [ ("python/a/b/foo_anchor.py", "FOO = 1 # #(ref:foo)")
@@ -140,3 +232,27 @@ spec = do
                 }
         withCurrentDirectory "python/a/b/" $
           findRefsFromGit defaultOpts `shouldSatisfy` P.returns (P.eq expected)
+
+    it "finds untracked references from a subdirectory" $ do
+      -- Untracked files anywhere in the repo (including outside the current
+      -- directory) must be found, with paths relative to the repo root.
+      let files =
+            [ (Tracked, "sub/deep/tracked.md", "@(ref:tracked)")
+            , (Untracked, "sub/deep/untracked.md", "@(ref:untracked-here)")
+            , (Untracked, "root-untracked.md", "@(ref:untracked-root)")
+            ]
+      withGitRepoAndFileStates files $ do
+        let expected =
+              SearchResult
+                { delims = defaultOpts.delims
+                , anchors = mempty
+                , references =
+                    Map.fromList
+                      [ ref "tracked" [loc' "sub/deep/tracked.md" 1 (1, 14)]
+                      , ref "untracked-here" [loc' "sub/deep/untracked.md" 1 (1, 21)]
+                      , ref "untracked-root" [loc' "root-untracked.md" 1 (1, 21)]
+                      ]
+                }
+        withCurrentDirectory "sub/deep" $
+          findRefsFromGit defaultOpts{includeUntracked = True}
+            `shouldSatisfy` P.returns (P.eq expected)

--- a/test/XReferee/TestUtils/Git.hs
+++ b/test/XReferee/TestUtils/Git.hs
@@ -1,10 +1,14 @@
 module XReferee.TestUtils.Git (
   withGitRepo,
+  GitFileState (..),
+  withGitRepoAndFileStates,
 ) where
 
 import Control.Exception (onException)
-import Control.Monad (forM_)
+import Control.Monad (forM_, unless)
+import Data.Functor ((<&>))
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Text.IO qualified as Text
 import System.Directory (
   createDirectoryIfMissing,
@@ -16,7 +20,12 @@ import System.IO.Temp (withSystemTempDirectory)
 import System.Process qualified as Process
 
 withGitRepo :: [(FilePath, Text)] -> IO a -> IO a
-withGitRepo files action =
+withGitRepo files =
+  withGitRepoAndFileStates $ files <&> \(relpath, content) -> (Tracked, relpath, content)
+
+-- | Create a temporary git repo whose files are in the given states.
+withGitRepoAndFileStates :: [(GitFileState, FilePath, Text)] -> IO a -> IO a
+withGitRepoAndFileStates files action =
   withSystemTempDirectory "git.XXXX" $ \tmpdir -> do
     let gitdir = tmpdir </> "repo"
         gitlog = tmpdir </> "git.log"
@@ -24,21 +33,45 @@ withGitRepo files action =
     createDirectoryIfMissing True gitdir
     withCurrentDirectory gitdir . captureLogs gitlog $ do
       git ["init"]
-      forM_ files $ \(relpath, content) -> do
+      -- Write every file to disk.
+      forM_ files $ \(_, relpath, content) -> do
         let fp = gitdir </> relpath
         createDirectoryIfMissing True (takeDirectory fp)
         Text.writeFile fp content
-      git ["add", "."]
+
+      -- Commit the tracked files *before* any .gitignore exists, so that
+      -- TrackedIgnored files stay tracked once they are later ignored.
+      let trackedPaths = [p | (st, p, _) <- files, st `elem` [Tracked, TrackedIgnored]]
+      forM_ trackedPaths $ \p -> git ["add", "--", p]
       git ["commit", "-m", "Initial commit", "--allow-empty", "--no-verify"]
+
+      -- Now ignore the ignored files.
+      let ignoredPaths = [p | (st, p, _) <- files, st `elem` [TrackedIgnored, UntrackedIgnored]]
+      unless (null ignoredPaths) $ do
+        Text.writeFile (gitdir </> ".gitignore") (T.unlines (T.pack <$> ignoredPaths))
+        git ["add", "--", ".gitignore"]
+        git ["commit", "-m", "Add .gitignore", "--no-verify"]
       action
   where
     captureLogs logFile f = f `onException` (readFile logFile >>= putStrLn)
 
-    runGit logFile args = do
-      (code, stdout, stderr) <- Process.readProcessWithExitCode "git" args ""
-      appendFile logFile stdout
-      appendFile logFile stderr
-      case code of
-        ExitSuccess -> pure ()
-        ExitFailure n -> do
-          fail $ "command exited with code " <> show n <> ": " <> show ("git" : args)
+data GitFileState
+  = -- | committed, not ignored
+    Tracked
+  | -- | committed, then added to @.gitignore@ in a later commit
+    TrackedIgnored
+  | -- | on disk, never staged, not ignored
+    Untracked
+  | -- | on disk, never staged, ignored
+    UntrackedIgnored
+  deriving (Eq)
+
+runGit :: FilePath -> [String] -> IO ()
+runGit logFile args = do
+  (code, stdout, stderr) <- Process.readProcessWithExitCode "git" args ""
+  appendFile logFile stdout
+  appendFile logFile stderr
+  case code of
+    ExitSuccess -> pure ()
+    ExitFailure n ->
+      fail $ "command exited with code " <> show n <> ": " <> show ("git" : args)

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:
     XReferee.Report
     XReferee.SearchResult
+    XReferee.Utils.Proc
     XReferee.Utils.Utf16
   build-depends:
       base < 5

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -47,7 +47,7 @@ executable xreferee
     , text
     , xreferee
   default-language: GHC2021
-  ghc-options: -Wall -Wcompat
+  ghc-options: -Wall -Wcompat -threaded -rtsopts "-with-rtsopts=-N"
 
 test-suite referee-tests
   type: exitcode-stdio-1.0

--- a/xreferee.cabal
+++ b/xreferee.cabal
@@ -30,6 +30,7 @@ library
     XReferee.Utils.Utf16
   build-depends:
       base < 5
+    , async
     , bytestring
     , containers
     , deepseq


### PR DESCRIPTION
Fixed #27 

Added regression tests, and also tested this on the demo repo at https://github.com/dcastro/xreferee-test

Before the fix, the file `tracked-ignored.md` would not be scanned:

```
$ xreferee --ignore setup-repo.sh --include-untracked
========== Broken references ==========
@(ref:broken)
    untracked-not-ignored.md:1
@(ref:broken-index-and-working-tree)
    tracked-not-ignored.md:1
@(ref:broken-working-tree-only)
    tracked-not-ignored.md:2
    tracked-not-ignored.md:3
    tracked-not-ignored.md:4
```

After the fix, it is:

```
$ xreferee --ignore setup-repo.sh --include-untracked
========== Broken references ==========
@(ref:broken)
    tracked-ignored.md:1
    untracked-not-ignored.md:1
@(ref:broken-index-and-working-tree)
    tracked-not-ignored.md:1
@(ref:broken-working-tree-only)
    tracked-not-ignored.md:2
    tracked-not-ignored.md:3
    tracked-not-ignored.md:4
```